### PR TITLE
2.3.x+deploy vbscript memory

### DIFF
--- a/contrib/windows/fusioninventory-agent-deployment.vbs
+++ b/contrib/windows/fusioninventory-agent-deployment.vbs
@@ -78,12 +78,12 @@ Dim Setup, SetupArchitecture, SetupLocation, SetupOptions, SetupVersion
 '       You also must be sure that you have removed the "Open File Security Warning"
 '       from programs accessed from that UNC.
 '
-SetupLocation = "http://freefr.dl.sourceforge.net/project/fiawi/2.3.x/2.3.0"
+SetupLocation = "http://freefr.dl.sourceforge.net/project/fiawi/2.3.x/2.3.4"
 
 ' SetupVersion
 '    Setup version with the pattern <major>.<minor>.<release>[-<package>]
 '
-SetupVersion = "2.3.0-1"
+SetupVersion = "2.3.4"
 
 ' SetupArchitecture
 '    The setup architecture can be 'x86', 'x64' or 'Auto'

--- a/contrib/windows/fusioninventory-agent-deployment.vbs
+++ b/contrib/windows/fusioninventory-agent-deployment.vbs
@@ -28,18 +28,19 @@
 '
 '  ------------------------------------------------------------------------
 '
-'  @package   FusionInventory Agent
-'  @file      .\contrib\windows\fusioninventory-agent-deployment.vbs
-'  @author(s) Benjamin Accary <meldrone@orange.fr>
-'             Christophe Pujol <chpujol@gmail.com>
-'             Marc Caissial <marc.caissial@zenitique.fr>
-'             Tomas Abad <tabadgp@gmail.com>
-'  @copyright Copyright (c) 2010-2013 FusionInventory Team
-'  @license   GNU GPL version 2 or (at your option) any later version
-'             http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
-'  @link      http://www.fusioninventory.org/
-'  @link      http://forge.fusioninventory.org/projects/fusioninventory-agent
-'  @since     2012
+'  @package    FusionInventory Agent
+'  @file       .\contrib\windows\fusioninventory-agent-deployment.vbs
+'  @author(s)  Benjamin Accary <meldrone@orange.fr>
+'              Christophe Pujol <chpujol@gmail.com>
+'              Marc Caissial <marc.caissial@zenitique.fr>
+'              Tomas Abad <tabadgp@gmail.com>
+'  @maintainer Tomas Abad <tabadgp@gmail.com>
+'  @copyright  Copyright (c) 2010-2013 FusionInventory Team
+'  @license    GNU GPL version 2 or (at your option) any later version
+'              http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html
+'  @link       http://www.fusioninventory.org/
+'  @link       http://forge.fusioninventory.org/projects/fusioninventory-agent
+'  @since      2012
 '
 '  ------------------------------------------------------------------------
 '


### PR DESCRIPTION
Hello,

I have made changes to include information a little more specific about the use of parameters and I have changed the name of variables 'SetupSmallMemory' and 'SetupOptionsSmallMemory' to 'SetupLowMemory' and 'SetupOptionsLowMemory' respectively.

The changes are tested. In fact, I going to start to use it tomorrow morning to deploy the new FusionInventory Agent 2.3.4 in near of 2000 computers.

You can do anything with these changes. I going to insist in them never more.

Best regards,