### PR TITLE
Include TL in AIX OS Version

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/AIX.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/AIX.pm
@@ -30,6 +30,9 @@ sub doInventory {
 
     my $OSLevel = getFirstLine(command => 'oslevel -r');
     my @OSLevelParts = split(/-/, $OSLevel);
+    
+    $version = "$version TL$OSLevelParts[1]";
+    $version =~ s/TL00*$//;
 
     my $Revision = getFirstLine(command => 'oslevel -s');
     my @RevisionParts = split(/-/, $Revision);


### PR DESCRIPTION
AIX version number consists of 3 parts : OS Base Level, Technolog Level (TL), and Service Packs. This is to include TL in the OS Verson field.

Ref: https://www.ibm.com/developerworks/community/blogs/AIXDownUnder/entry/understanding_aix_levels6?lang=en_us
