### PR TITLE
2.3.x+task collect

### DIFF
--- a/lib/FusionInventory/Agent/Task/Collect.pm
+++ b/lib/FusionInventory/Agent/Task/Collect.pm
@@ -76,7 +76,7 @@ sub _validateSpec {
             $self->{logger}->debug("$key mandatory values are missing in job");
             return 0;
         }
-        $self->{logger}->debug("$key mandatory values are present in job");
+        $self->{logger}->debug2("$key mandatory values are present in job");
         foreach my $attribute (keys(%{$spec})) {
             return 0 unless $self->_validateSpec($base->{$key}, $attribute, $spec->{$attribute});
         }
@@ -88,12 +88,12 @@ sub _validateSpec {
             $self->{logger}->debug("$key mandatory value is missing in job");
             return 0;
         }
-        $self->{logger}->debug("$key mandatory value is present in job with value '".$base->{$key}."'");
+        $self->{logger}->debug2("$key mandatory value is present in job with value '".$base->{$key}."'");
         return 1;
     }
 
     if ($spec == _OPTIONAL && exists($base->{$key})) {
-        $self->{logger}->debug("$key optional value is present in job with value '".$base->{$key}."'");
+        $self->{logger}->debug2("$key optional value is present in job with value '".$base->{$key}."'");
     }
 
     1;

--- a/lib/FusionInventory/Agent/Task/Collect.pm
+++ b/lib/FusionInventory/Agent/Task/Collect.pm
@@ -56,7 +56,7 @@ sub run {
         }
 
         if ( !defined( $functions{ $job->{function} } ) ) {
-            $self->{logger}->error("Bad function `$job->{function}'");
+            $self->{logger}->error("Bad function '$job->{function}'");
             next;
         }
 

--- a/lib/FusionInventory/Agent/Task/Collect.pm
+++ b/lib/FusionInventory/Agent/Task/Collect.pm
@@ -264,7 +264,7 @@ sub _getFromRegistry {
 
     return unless FusionInventory::Agent::Tools::Win32->require();
 
-    my $values = FusionInventory::Agent::Tools::Win32::getRegistryValues(path => $params{path});
+    my $values = FusionInventory::Agent::Tools::Win32::getRegistryValue(path => $params{path});
 
     return unless $values;
 

--- a/lib/FusionInventory/Agent/Task/Collect.pm
+++ b/lib/FusionInventory/Agent/Task/Collect.pm
@@ -138,7 +138,7 @@ sub _validateAnswer {
             return;
         }
 
-        foreach my $attribute (keys($json_validation{$function})) {
+        foreach my $attribute (keys(%{$json_validation{$function}})) {
             if (!$self->_validateSpec( $job, $attribute, $json_validation{$function}->{$attribute} )) {
                 $$msgRef = "'$function' job JSON format is not valid";
                 return;

--- a/lib/FusionInventory/Agent/Task/Collect.pm
+++ b/lib/FusionInventory/Agent/Task/Collect.pm
@@ -1,0 +1,235 @@
+package FusionInventory::Agent::Task::Collect;
+
+use strict;
+use warnings;
+use base 'FusionInventory::Agent::Task';
+
+use Digest::SHA;
+use English qw(-no_match_vars);
+use File::Basename;
+use File::Find;
+use File::stat;
+
+use FusionInventory::Agent;
+use FusionInventory::Agent::Logger;
+use FusionInventory::Agent::Tools;
+
+our $VERSION = $FusionInventory::Agent::VERSION;
+
+my %functions = (
+    getFromRegistry => \&_getFromRegistry,
+    findFile        => \&_findFile,
+# As decided by the FusInv-Agent developers, the runCommand function
+# is disabled for the moment.
+#    runCommand      => \&_runCommand,
+    getFromWMI      => \&_getFromWMI
+);
+
+sub getConfiguration {
+    my ($self, %params) = @_;
+
+    my $config = $params{spec}->{config};
+
+    return (
+        jobs => $config->{jobs}
+    );
+}
+
+sub run {
+    my ($self, %params) = @_;
+
+    my $target = $params{target}
+        or die "no target provided, aborting";
+    my @jobs = @{$self->{config}->{jobs}}
+        or die "no jobs provided, aborting";
+    my $max_workers = $self->{config}->{workers} || 0;
+
+    foreach my $job (@jobs) {
+        if ( !$job->{uuid} ) {
+            $self->{logger}->error("UUID key missing");
+            next;
+        }
+
+        if ( !$job->{function} ) {
+            $self->{logger}->error("function key missing");
+            next;
+        }
+
+        if ( !defined( $functions{ $job->{function} } ) ) {
+            $self->{logger}->error("Bad function `$job->{function}'");
+            next;
+        }
+
+        my @results = &{ $functions{ $job->{function} } }(%$job);
+
+        my $count = int(@results);
+        foreach my $result (@results) {
+            next unless ref($result) eq 'HASH';
+            next unless keys %$result;
+            $result->{uuid}   = $job->{uuid};
+            $result->{action} = "setAnswer";
+            $result->{_cpt}   = $count;
+            $target->send(
+                filename => sprintf('collect_%s_%s.js', $job->{uuid}, $count),
+                message  => $result
+            );
+            $count--;
+        }
+    }
+
+    return $self;
+}
+
+sub _getFromRegistry {
+    my %params = @_;
+
+    return unless FusionInventory::Agent::Tools::Win32->require();
+
+    my $values = FusionInventory::Agent::Tools::Win32::getRegistryValues(path => $params{path});
+
+    return unless $values;
+
+    my $result;
+    if (ref($values) eq 'HASH') { # I don't like that. We should always get href
+        foreach my $k (keys %$values) {
+            my $v = FusionInventory::Agent::Tools::Win32::encodeFromRegistry($values->{$k});
+            $result->{$k}=$v;
+        }
+    }
+
+    return ($result);
+}
+
+sub _findFile {
+    my %params = (
+        dir => '/',
+        limit => 50
+        , @_);
+
+    return unless -d $params{dir};
+
+    my @results;
+
+    File::Find::find(
+        {
+            wanted => sub {
+                if (!$params{recursive} && $File::Find::name ne $params{dir}) {
+                    $File::Find::prune = 1  # Don't recurse.
+                }
+
+
+                if (   $params{filter}{is_dir}
+                    && !$params{filter}{checkSumSHA512}
+                    && !$params{filter}{checkSumSHA2} )
+                {
+                    return unless -d $File::Find::name;
+                }
+
+                if ( $params{filter}{is_file} ) {
+                    return unless -f $File::Find::name;
+                }
+
+                my $filename = basename($File::Find::name);
+
+                if ( $params{filter}{name} ) {
+                    return if $filename ne $params{filter}{name};
+                }
+
+                if ( $params{filter}{iname} ) {
+                    return if lc($filename) ne lc( $params{filter}{iname} );
+                }
+
+                if ( $params{filter}{regex} ) {
+                    my $re = qr($params{filter}{regex});
+                    return unless $File::Find::name =~ $re;
+                }
+
+                my $st   = stat($File::Find::name);
+                my $size = $st->size;
+                if ( $params{filter}{sizeEquals} ) {
+                    return unless $size == $params{filter}{sizeEquals};
+                }
+
+                if ( $params{filter}{sizeGreater} ) {
+                    return if $size < $params{filter}{sizeGreater};
+                }
+
+                if ( $params{filter}{sizeLower} ) {
+                    return if $size > $params{filter}{sizeLower};
+                }
+
+                if ( $params{filter}{checkSumSHA512} ) {
+                    my $sha = Digest::SHA->new('512');
+                    $sha->addfile( $File::Find::name, 'b' );
+                    return
+                        if $sha->hexdigest ne $params{filter}{checkSumSHA512};
+                }
+
+                if ( $params{filter}{checkSumSHA2} ) {
+                    my $sha = Digest::SHA->new('2');
+                    $sha->addfile( $File::Find::name, 'b' );
+                    return
+                        if $sha->hexdigest ne $params{filter}{checkSumSHA2};
+                }
+
+                push @results, {
+                    size => $size,
+                    path => $File::Find::name
+                };
+                goto DONE if @results >= $params{limit};
+            },
+            no_chdir => 1
+
+        },
+        $params{dir}
+    );
+    DONE:
+
+    return @results;
+}
+
+sub _runCommand {
+    my %params = @_;
+
+    my $line;
+
+    if ( $params{filter}{firstMatch} ) {
+        $line = getFirstMatch(
+            command => $params{command},
+            pattern => $params{filter}{firstMatch}
+        );
+    }
+    elsif ( $params{filter}{firstLine} ) {
+        $line = getFirstLine( command => $params{command} );
+
+    }
+    elsif ( $params{filter}{lineCount} ) {
+        $line = getLinesCount( command => $params{command} );
+    }
+    else {
+        $line = getAllLines( command => $params{command} );
+
+    }
+
+    return ( { output => $line } );
+}
+
+sub _getFromWMI {
+    my %params = @_;
+
+    return unless FusionInventory::Agent::Tools::Win32->require();
+
+    return unless $params{properties};
+    return unless $params{class};
+
+    my @results;
+
+    my @objects = FusionInventory::Agent::Tools::Win32::getWMIObjects(%params);
+    foreach my $object (@objects) {
+        push @results, $object;
+    }
+
+    return @results;
+}
+
+1;

--- a/t/tasks/collect.t
+++ b/t/tasks/collect.t
@@ -3,85 +3,173 @@
 use strict;
 use warnings;
 use lib 't/lib';
+use File::Temp qw(tempdir);
 
 use Test::Exception;
 use Test::More;
 
 use FusionInventory::Agent::Logger;
 use FusionInventory::Agent::Task::Collect;
+use FusionInventory::Agent::Target::Server;
 
 my $logger = FusionInventory::Agent::Logger->new(
     backends => [ 'Fatal' ]
+);
+
+my $target = FusionInventory::Agent::Target::Server->new(
+    url    => 'http://localhost/glpi-any',
+    logger => $logger,
+    basevardir => tempdir(CLEANUP => 1)
 );
 
 my $task = undef ;
 
 my %params = ();
 
-my $plan = 10;
+my $plan = 15;
 
 plan tests => $plan;
 
+# Redefine send API for testing to simulate server answer without really sending
+# user & password params can be used to define the current test and simulate the expected answer
+sub FusionInventory::Agent::HTTP::Client::Fusion::send {
+    my ($self, %params) = @_;
+    my $test = $self->{user} || '' ;
+    my $remtest = $self->{password} || '' ;
+    die 'communication error' if ($test eq 'nocomm');
+    die 'no arg to send' unless exists($params{args});
+    if ($params{args}->{action} eq 'getConfig') {
+        if ($test eq 'noschedule') {
+            return {};
+        } elsif ( $test eq 'emptyschedule' ) {
+            return {
+                schedule => []
+            };
+        } elsif ( $test eq 'badschedule' ) {
+            return {
+                schedule => [{}]
+            };
+        } elsif ( $test eq 'normalschedule' ) {
+            return {
+                schedule => [
+                    {
+                        task => 'Collect'
+                    }
+                ]
+            };
+        } elsif ( $test eq 'normalschedulewithremoteurl' ) {
+            return {
+                schedule => [
+                    {
+                        task   => 'Collect',
+                        remote => 'xxx'
+                    }
+                ]
+            };
+        }
+    } elsif ($params{args}->{action} eq 'getJobs') {
+        if ( $remtest eq 'nojob' ) {
+            return {};
+        } elsif ( $remtest eq 'badjson-1' ) {
+            return 'bad';
+        } elsif ( $remtest eq 'badjson-2' ) {
+            return {
+                bad => ''
+            };
+        } elsif ( $remtest eq 'badjson-3' ) {
+            return {
+                jobs => ''
+            };
+        } elsif ( $remtest eq 'badjson-4' ) {
+            return {
+                jobs => [ {} ]
+            };
+        } elsif ( $remtest eq 'badjson-5' ) {
+            return {
+                jobs => [ {
+                        uuid => ''
+                    } ]
+            };
+        } elsif ( $remtest eq 'badjson-6' ) {
+            return {
+                jobs => [ {
+                        uuid     => '',
+                        function => ''
+                    } ]
+            };
+        } elsif ( $remtest eq 'unexpected-nojob' ) {
+            return {
+                jobs => []
+            };
+        }
+    }
+}
+
+# Set greater verbosity to trigger tests on expected debug message
+$logger->{verbosity} = LOG_DEBUG2;
+
 lives_ok {
     $task = FusionInventory::Agent::Task::Collect->new(
-        target => 'xxx',
+        target => $target,
         logger => $logger,
+        debug  => 1,
         config => {
             jobs => []
         }
     );
 } "Collect object instanciation" ;
-is( $task->{target}, 'xxx' );
+is( $target->getUrl(), 'http://localhost/glpi-any' );
 
 throws_ok {
-    FusionInventory::Agent::Task::Collect->run();
-} qr/no target provided/, "Normal no target failure on run API call" ;
-
-throws_ok {
-    $task->run();
-} qr/no target provided/, "Normal no target task failure on run method" ;
-
-$params{target} = 'yyy';
-throws_ok {
-    $task->run(%params);
-} qr/no jobs provided/, "Normal no job failure" ;
-
-my $job = {};
-push @{$task->{config}->{jobs}}, $job ;
-
-throws_ok {
-    $task->run(%params);
-} qr/UUID key missing/, "Will skip job without UUID" ;
-
-$job->{uuid} = 'zzz';
-throws_ok {
-    $task->run(%params);
-} qr/function key missing/, "Will skip job without specified function" ;
-
-$job->{function} = 'unknown collect function';
-throws_ok {
-    $task->run(%params);
-} qr/Bad function/, "Will skip job with unknown function" ;
-
-# We need to fake a target so runmethod can be called back in 'run' method
-my $target = {};
-bless $target, "Fake::Target";
-$params{target} = $target;
-
-my $returned_object = undef ;
-
-$job->{function} = 'findFile';
+    $task->run( user => 'nocomm' );
+} qr/communication error/, "Normal error if target is unavailable" ;
 
 lives_ok {
-    $returned_object = $task->run(%params);
-} "Normal run using 'findFile' known function" ;
+    $task->run( user => 'noschedule' );
+} "Normal return on no scheduled task found" ;
 
-is($returned_object, $task);
+lives_ok {
+    $task->run( user => 'emptyschedule' );
+} "Normal return on empty schedule" ;
 
-# Fake target class to just simulate needed 'send' method
-package Fake::Target;
+lives_ok {
+    $task->run( user => 'badschedule' );
+} "No nothing with bad job schedule" ;
 
-sub send {
-}
+lives_ok {
+    $task->run( user => 'normalschedule' );
+} "Normal schedule" ;
+
+throws_ok {
+    $task->run( user => 'normalschedulewithremoteurl', password => 'nojob' );
+} qr/Nothing to do/, "No job scheduled" ;
+
+throws_ok {
+    $task->run( user => 'normalschedulewithremoteurl', password => 'badjson-1' );
+} qr/Bad JSON.*Bad answer/, "Badly formatted job - case 1" ;
+
+throws_ok {
+    $task->run( user => 'normalschedulewithremoteurl', password => 'badjson-2' );
+} qr/Bad JSON.*Missing jobs/, "Badly formatted job - case 2" ;
+
+throws_ok {
+    $task->run( user => 'normalschedulewithremoteurl', password => 'badjson-3' );
+} qr/Bad JSON.*Missing jobs/, "Badly formatted job - case 3" ;
+
+throws_ok {
+    $task->run( user => 'normalschedulewithremoteurl', password => 'badjson-4' );
+} qr/Bad JSON.*Missing key/, "Badly formatted job - case 4" ;
+
+throws_ok {
+    $task->run( user => 'normalschedulewithremoteurl', password => 'badjson-5' );
+} qr/Bad JSON.*Missing key/, "Badly formatted job - case 5" ;
+
+throws_ok {
+    $task->run( user => 'normalschedulewithremoteurl', password => 'badjson-6' );
+} qr/Bad JSON.*not supported 'function' key/, "Badly formatted job - case 6" ;
+
+throws_ok {
+    $task->run( user => 'normalschedulewithremoteurl', password => 'unexpected-nojob' );
+} qr/no jobs provided/, "No job included in jobs key" ;
 
 1

--- a/t/tasks/collect.t
+++ b/t/tasks/collect.t
@@ -1,0 +1,87 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use lib 't/lib';
+
+use Test::Exception;
+use Test::More;
+
+use FusionInventory::Agent::Logger;
+use FusionInventory::Agent::Task::Collect;
+
+my $logger = FusionInventory::Agent::Logger->new(
+    backends => [ 'Fatal' ]
+);
+
+my $task = undef ;
+
+my %params = ();
+
+my $plan = 10;
+
+plan tests => $plan;
+
+lives_ok {
+    $task = FusionInventory::Agent::Task::Collect->new(
+        target => 'xxx',
+        logger => $logger,
+        config => {
+            jobs => []
+        }
+    );
+} "Collect object instanciation" ;
+is( $task->{target}, 'xxx' );
+
+throws_ok {
+    FusionInventory::Agent::Task::Collect->run();
+} qr/no target provided/, "Normal no target failure on run API call" ;
+
+throws_ok {
+    $task->run();
+} qr/no target provided/, "Normal no target task failure on run method" ;
+
+$params{target} = 'yyy';
+throws_ok {
+    $task->run(%params);
+} qr/no jobs provided/, "Normal no job failure" ;
+
+my $job = {};
+push @{$task->{config}->{jobs}}, $job ;
+
+throws_ok {
+    $task->run(%params);
+} qr/UUID key missing/, "Will skip job without UUID" ;
+
+$job->{uuid} = 'zzz';
+throws_ok {
+    $task->run(%params);
+} qr/function key missing/, "Will skip job without specified function" ;
+
+$job->{function} = 'unknown collect function';
+throws_ok {
+    $task->run(%params);
+} qr/Bad function/, "Will skip job with unknown function" ;
+
+# We need to fake a target so runmethod can be called back in 'run' method
+my $target = {};
+bless $target, "Fake::Target";
+$params{target} = $target;
+
+my $returned_object = undef ;
+
+$job->{function} = 'findFile';
+
+lives_ok {
+    $returned_object = $task->run(%params);
+} "Normal run using 'findFile' known function" ;
+
+is($returned_object, $task);
+
+# Fake target class to just simulate needed 'send' method
+package Fake::Target;
+
+sub send {
+}
+
+1

--- a/t/tasks/collect/findfile.t
+++ b/t/tasks/collect/findfile.t
@@ -1,0 +1,250 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use lib 't/lib';
+use File::Temp qw(tempdir);
+
+use Test::Exception;
+use Test::More;
+use Test::Deep qw(cmp_deeply);
+
+use FusionInventory::Agent::Logger;
+use FusionInventory::Agent::Task::Collect;
+use FusionInventory::Agent::Target::Server;
+
+my $logger = FusionInventory::Agent::Logger->new(
+    backends => [ 'Fatal' ]
+);
+
+my $target = FusionInventory::Agent::Target::Server->new(
+    url    => 'http://localhost/glpi-any',
+    logger => $logger,
+    basevardir => tempdir(CLEANUP => 1)
+);
+
+my %tests = (
+    FF1 => {
+        OK   => 'no',
+        description => "Missing mandatory recursive value",
+        getJobs => {
+            jobs => [
+                {
+                    uuid     => '',
+                    function => 'findFile',
+                    dir      => '',
+                    limit    => 0,
+                    filter   => {
+                        is_file => 0,
+                        is_dir  => 0
+                    }
+                }
+            ]
+        },
+        expected => qr/mandatory value is missing/
+    },
+    FF2 => {
+        OK   => 'no',
+        description => "Missing mandatory dir value",
+        getJobs => {
+            jobs => [
+                {
+                    uuid      => '',
+                    function  => 'findFile',
+                    recursive => '',
+                    limit     => 0,
+                    filter    => {
+                        is_file => 0,
+                        is_dir  => 0
+                    }
+                }
+            ]
+        },
+        expected => qr/mandatory value is missing/
+    },
+    FF3 => {
+        OK   => 'no',
+        description => "Missing mandatory limit value",
+        getJobs => {
+            jobs => [
+                {
+                    uuid      => '',
+                    function  => 'findFile',
+                    recursive => '',
+                    dir       => '.',
+                    filter    => {
+                        is_file => 0,
+                        is_dir  => 0
+                    }
+                }
+            ]
+        },
+        expected => qr/mandatory value is missing/
+    },
+    FF4 => {
+        OK   => 'no',
+        description => "Missing mandatory filter value",
+        getJobs => {
+            jobs => [
+                {
+                    uuid      => '',
+                    function  => 'findFile',
+                    recursive => '',
+                    dir       => '.',
+                    limit     => 0
+                }
+            ]
+        },
+        expected => qr/mandatory values are missing/
+    },
+    FF5 => {
+        OK   => 'no',
+        description => "Missing mandatory is_dir value",
+        getJobs => {
+            jobs => [
+                {
+                    uuid      => '',
+                    function  => 'findFile',
+                    recursive => '',
+                    dir       => '.',
+                    limit     => 0,
+                    filter    => {
+                        is_file => 0
+                    }
+                }
+            ]
+        },
+        expected => qr/mandatory value is missing/
+    },
+    FF6 => {
+        OK   => 'no',
+        description => "Missing mandatory is_file value",
+        getJobs => {
+            jobs => [
+                {
+                    uuid      => '',
+                    function  => 'findFile',
+                    recursive => '',
+                    dir       => '.',
+                    limit     => 0,
+                    filter    => {
+                        is_dir  => 0
+                    }
+                }
+            ]
+        },
+        expected => qr/mandatory value is missing/
+    },
+    FF7 => {
+        OK   => 'no',
+        description => "Missing mandatory job UUID value",
+        getJobs => {
+            jobs => [
+                {
+                    uuid      => '',
+                    function  => 'findFile',
+                    recursive => '',
+                    dir       => '.',
+                    limit     => 0,
+                    filter    => {
+                        is_file => 0,
+                        is_dir  => 0
+                    }
+                }
+            ]
+        },
+        expected => qr/UUID key missing/
+    },
+    FF8 => {
+        OK   => 'yes',
+        description => "n/a",
+        getJobs => {
+            jobs => [
+                {
+                    uuid      => 'collecting-agent',
+                    function  => 'findFile',
+                    recursive => '',
+                    dir       => '.',
+                    limit     => 0,
+                    filter    => {
+                        is_file => 0,
+                        is_dir  => 0
+                    }
+                }
+            ]
+        },
+        count   => 1,
+        results => [
+            {
+                '_cpt' => 1,
+                'path' => '.',
+                'size' => '4096'
+            }
+        ]
+    }
+);
+
+# Redefine send API for testing to simulate server answer without really sending
+# user & password params can be used to define the current test and simulate the expected answer
+sub FusionInventory::Agent::HTTP::Client::Fusion::send {
+    my ($self, %params) = @_;
+    my $test = $self->{user} || '' ;
+    die 'communication error' if ($test eq 'nocomm');
+    die 'no arg to send' unless exists($params{args});
+    die 'no such test' unless exists($tests{$test});
+    if ($params{args}->{action} eq 'getConfig') {
+        return {
+            schedule => [
+                {
+                    task   => 'Collect',
+                    remote => 'http://somewhere/glpi/plugins/fusioninventory/b/collect/'
+                }
+            ]
+        };
+    } elsif ($params{args}->{action} eq 'getJobs') {
+        return $tests{$test}->{getJobs} ;
+    } elsif ($params{args}->{action} eq 'setAnswer') {
+        $tests{$test}->{setAnswer} = []
+            unless exists($tests{$test}->{setAnswer}) ;
+        delete $params{args}->{uuid};
+        delete $params{args}->{action};
+        push @{$tests{$test}->{setAnswer}}, $params{args};
+        return {} ;
+    }
+    die 'no expected test case';
+}
+
+# Set greater verbosity to trigger tests on expected debug message
+$logger->{verbosity} = LOG_DEBUG;
+
+plan tests => 1 + scalar(keys(%tests)) + 2*scalar(grep { $_->{OK} eq 'yes' } values(%tests));
+
+my $task = undef ;
+lives_ok {
+    $task = FusionInventory::Agent::Task::Collect->new(
+        target => $target,
+        logger => $logger,
+        debug  => 1,
+        config => {
+            jobs => []
+        }
+    );
+} "Collect object instanciation" ;
+
+foreach my $test (sort keys %tests) {
+    if ($tests{$test}->{OK} eq 'yes') {
+        lives_ok {
+            $task->run( user => $test );
+        } "Test $test: ".$tests{$test}->{description} ;
+        cmp_deeply( $tests{$test}->{setAnswer}, $tests{$test}->{results}, "$test results")
+            || diag explain $tests{$test}->{setAnswer};
+        is( scalar(@{$tests{$test}->{setAnswer}}), $tests{$test}->{count}, "$test results count");
+    } else {
+        throws_ok {
+            $task->run( user => $test );
+        } $tests{$test}->{expected},
+            "Test $test: ".$tests{$test}->{description} ;
+    }
+}
+
+1


### PR DESCRIPTION
This is my first attempt to fix and enhance the collect task in agent for 2.3.x branch.

It includes a FusionInventory::Agent::HTTP::Client::Fusion modification to automatically use POST method in the case remote fusioninventory-for-glpi plugin supports it (a separate pull request for 0.84 plugin branch will be available). This enhancement is also CRSF compliant as requested for the GLPI plugin.

I added unit tests. findFile collect function case unit tests are not complete and I need to add unit tests dedicated to getFromRegistry and getFromWMI functions.