### PR TITLE
Add the possibility to consider aggregation ports as trunk ports

### DIFF
--- a/bin/fusioninventory-netinventory
+++ b/bin/fusioninventory-netinventory
@@ -135,6 +135,7 @@ $agent->initHandlers();
 
 my $task = FusionInventory::Agent::Task::NetInventory->new(
     logger => $logger,
+    config => $config,
 );
 
 $task->configure(

--- a/etc/agent.cfg
+++ b/etc/agent.cfg
@@ -110,6 +110,10 @@ disable = 0
 # default PVID for trunk port is 0
 trunk_pvid = 0
 
+# Consider aggregation ports as trunk ports for non-Cisco switches
+# Set it to 1 if you encounter association  problems with aggregation bridges
+aggregation_as_trunk = 0
+
 # collect module specific options
 [collect]
 # disable module

--- a/etc/agent.cfg
+++ b/etc/agent.cfg
@@ -107,6 +107,9 @@ disable = 0
 # disable module
 disable = 0
 
+# default PVID for trunk port is 0
+trunk_pvid = 0
+
 # collect module specific options
 [collect]
 # disable module

--- a/etc/agent.cfg.pod
+++ b/etc/agent.cfg.pod
@@ -251,6 +251,14 @@ Disable module (default: 0).
 
 Disable module (default: 0).
 
+=item B<trunk_pvid>
+
+Allow to change the PVID (VLAN IDentifier) used to define which ports should be considered as trunk (default: 0).
+This option does nothing on Cisco and Juniper switches.
+Possible values can be found by doing an SNMP walk through the C<.1.0.8802.1.1.2.1.5.32962.1.2.1.1.1> OID : 
+
+ snmpwalk -c COMMUNITY -v2c IP_ADDRESS_OF_YOUR_SWITCH .1.0.8802.1.1.2.1.5.32962.1.2.1.1.1
+
 =back
 
 =head1 COLLECT MODULE OPTIONS

--- a/etc/agent.cfg.pod
+++ b/etc/agent.cfg.pod
@@ -259,6 +259,12 @@ Possible values can be found by doing an SNMP walk through the C<.1.0.8802.1.1.2
 
  snmpwalk -c COMMUNITY -v2c IP_ADDRESS_OF_YOUR_SWITCH .1.0.8802.1.1.2.1.5.32962.1.2.1.1.1
 
+=item B<aggregation_as_trunk>
+
+Consider aggregation ports as trunk ports.
+Set it to 1 if you encounter association problems with aggregation bridges
+This option does nothing on Cisco switches.
+
 =back
 
 =head1 COLLECT MODULE OPTIONS

--- a/lib/FusionInventory/Agent/Config.pm
+++ b/lib/FusionInventory/Agent/Config.pm
@@ -50,8 +50,9 @@ my $valid = {
             'disable'            => 'boolean',
         },
         netinventory => {
-            'disable'            => 'boolean',
-            'trunk_pvid'         => 'integer',
+            'disable'              => 'boolean',
+            'trunk_pvid'           => 'integer',
+            'aggregation_as_trunk' => 'boolean',
         },
         netdiscovery => {
             'disable'            => 'boolean',
@@ -260,8 +261,9 @@ sub new {
             'disable'            => 0,
         },
         netinventory => {
-            'disable'            => 0,
-            'trunk_pvid'         => 0,
+            'disable'              => 0,
+            'trunk_pvid'           => 0,
+            'aggregation_as_trunk' => 0,
         },
         netdiscovery => {
             'disable'            => 0,

--- a/lib/FusionInventory/Agent/Config.pm
+++ b/lib/FusionInventory/Agent/Config.pm
@@ -51,6 +51,7 @@ my $valid = {
         },
         netinventory => {
             'disable'            => 'boolean',
+            'trunk_pvid'         => 'integer',
         },
         netdiscovery => {
             'disable'            => 'boolean',
@@ -260,6 +261,7 @@ sub new {
         },
         netinventory => {
             'disable'            => 0,
+            'trunk_pvid'         => 0,
         },
         netdiscovery => {
             'disable'            => 0,

--- a/lib/FusionInventory/Agent/Task.pm
+++ b/lib/FusionInventory/Agent/Task.pm
@@ -14,6 +14,7 @@ sub new {
 
     my $self = {
         logger => $params{logger} || FusionInventory::Agent::Logger->new(),
+        config => $params{config},
     };
     bless $self, $class;
 

--- a/lib/FusionInventory/Agent/Task/NetInventory.pm
+++ b/lib/FusionInventory/Agent/Task/NetInventory.pm
@@ -160,6 +160,7 @@ sub _queryDevice {
          snmp    => $snmp,
          logger  => $self->{logger},
          dbdir   => $self->{config}->{datadir} . '/db',
+         config  => $self->{config}
     );
     $self->_sendResultMessage($result, $source);
 }

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -1453,6 +1453,7 @@ sub _getTrunkPorts {
     my (%params) = @_;
 
     my $snmp   = $params{snmp};
+	my $config = $params{config};
 
     my $results;
 
@@ -1496,7 +1497,7 @@ sub _getTrunkPorts {
             my $interface_id =
                 ! exists $port2interface->{$id} ? $id                   :
                                                   $port2interface->{$id};
-            $results->{$interface_id} = $value == 0 ? 1 : 0;
+            $results->{$interface_id} = $value == $config->{netinventory}->{trunk_pvid} ? 1 : 0;
         }
         return $results;
     }

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -524,6 +524,7 @@ sub getDeviceFullInfo {
 
     my $snmp   = $params{snmp};
     my $logger = $params{logger};
+    my $config = $params{config};
 
     # first, let's retrieve basic device informations
     my $info = getDeviceInfo(%params);
@@ -571,7 +572,8 @@ sub getDeviceFullInfo {
         device  => $device,
         snmp    => $snmp,
         logger  => $logger,
-        dbdir   => $params{dbdir}
+        dbdir   => $params{dbdir},
+        config  => $config
     ) if $info->{TYPE} && $info->{TYPE} eq 'NETWORKING';
 
     # convert ports hashref to an arrayref, sorted by interface number
@@ -782,6 +784,7 @@ sub _setNetworkingProperties {
     my $device = $params{device};
     my $snmp   = $params{snmp};
     my $logger = $params{logger};
+    my $config = $params{config};
 
     my $ports    = $device->{PORTS}->{PORT};
 
@@ -794,7 +797,8 @@ sub _setNetworkingProperties {
     _setTrunkPorts(
         snmp   => $snmp,
         ports  => $ports,
-        logger => $logger
+        logger => $logger,
+        config => $config
     );
 
     _setConnectedDevices(
@@ -1429,7 +1433,8 @@ sub _setTrunkPorts {
     my (%params) = @_;
 
     my $trunk_ports = _getTrunkPorts(
-        snmp  => $params{snmp},
+        snmp   => $params{snmp},
+        config => $params{config},
     );
     return unless $trunk_ports;
 
@@ -1453,7 +1458,7 @@ sub _getTrunkPorts {
     my (%params) = @_;
 
     my $snmp   = $params{snmp};
-	my $config = $params{config};
+    my $config = $params{config};
 
     my $results;
 
@@ -1497,7 +1502,7 @@ sub _getTrunkPorts {
             my $interface_id =
                 ! exists $port2interface->{$id} ? $id                   :
                                                   $port2interface->{$id};
-            $results->{$interface_id} = $value == $config->{netinventory}->{trunk_pvid} ? 1 : 0;
+            $results->{$interface_id} = $value == $config->{netinventory}->{'trunk_pvid'} ? 1 : 0;
         }
         return $results;
     }

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -817,7 +817,8 @@ sub _setNetworkingProperties {
     _setAggregatePorts(
         snmp   => $snmp,
         ports  => $ports,
-        logger => $logger
+        logger => $logger,
+        config => $config
     );
 }
 
@@ -1515,6 +1516,7 @@ sub _setAggregatePorts {
 
     my $ports  = $params{ports};
     my $logger = $params{logger};
+    my $config = $params{config};
 
     my $lacp_info = _getLACPInfo(%params);
     if ($lacp_info) {
@@ -1527,6 +1529,11 @@ sub _setAggregatePorts {
                 next;
             }
             $ports->{$interface_id}->{AGGREGATE}->{PORT} = $lacp_info->{$interface_id};
+			
+            # Consider aggregation ports as trunk ports, to prevent assocations problems in GLPI with non-cisco switches.
+            if($config->{netinventory}->{'aggregation_as_trunk'} == 1){
+                $ports->{$interface_id}->{TRUNK} = "1";
+            }
         }
     }
 


### PR DESCRIPTION
These commits add the possibility to consider aggregation ports as trunk ports to fix some association issues with non-cisco switches.
