### PR TITLE
2.3.x+net tasks multi threading refactoring

### DIFF
--- a/bin/fusioninventory-netinventory
+++ b/bin/fusioninventory-netinventory
@@ -24,7 +24,8 @@ my %types = (
 );
 
 my $options = {
-    debug => 0
+    debug => 0,
+    threads => 1
 };
 
 my %setup = (
@@ -42,7 +43,7 @@ GetOptions(
     'file=s',
     'community=s',
     'credentials=s',
-    'entity=s',
+    'threads=i',
     'timeout=i',
     'control',
     'debug+',
@@ -62,13 +63,15 @@ pod2usage(
 
 warn "deprecated option model, ignoring\n" if $options->{model};
 
-my $device = {
-    ID           => 0,
-    IP           => $options->{host},
-    FILE         => $options->{file},
-    AUTHSNMP_ID  => 1,
-    MODELSNMP_ID => 1
-};
+my @devices = map {
+        {
+            ID           => 0,
+            IP           => $_,
+            FILE         => $options->{file},
+            AUTHSNMP_ID  => 1,
+            MODELSNMP_ID => 1
+        }
+    } split(/,+/,$options->{host});
 
 my $credentials = { ID => 1 };
 
@@ -77,7 +80,7 @@ if ($options->{type}) {
         -message => "invalid type '$options->{type}', aborting\n",
         -verbose => 0
     ) unless any { $options->{type} eq $_ } values %types;
-    $device->{TYPE} = $options->{type};
+    map { $_->{TYPE} = $options->{type} } @devices;
 }
 
 if ($options->{community}) {
@@ -93,10 +96,6 @@ if ($options->{community}) {
     }
 } else {
     $credentials->{COMMUNITY} = 'public';
-}
-
-if ($options->{entity}) {
-    $device = $options->{entity};
 }
 
 my $verbosity =
@@ -115,10 +114,10 @@ $inventory->{jobs} = [
     {
         params => {
             PID           => 1,
-            THREADS_QUERY => 1,
+            THREADS_QUERY => $options->{threads},
             TIMEOUT       => $options->{timeout},
         },
-        devices     => [ $device ],
+        devices     => \@devices,
         credentials => [ $credentials ]
     }
 ];
@@ -175,15 +174,15 @@ fusioninventory-netinventory - Standalone network inventory
 
 =head1 SYNOPSIS
 
-fusioninventory-netinventory [options] [--host <host>--file <file>]
+fusioninventory-netinventory [options] [--host <host>|--file <file>]
 
   Options:
-    --host host    host to inventorize
+    --host host    host(s) to inventorize, uses comma to separate hosts
     --file         snmpwalk output file
     --community    community string (default: public)
     --credentials  SNMP credentials
     --timeout val  SNMP timeout (default: 15s)
-    --entity       GLPI entity
+    --threads nb   number of invenroty threads (default: 1)
     --control      output control messages
     --debug        debug output (execution traces)
     -h --help      print this message and exit

--- a/lib/FusionInventory/Agent/Task/NetDiscovery.pm
+++ b/lib/FusionInventory/Agent/Task/NetDiscovery.pm
@@ -10,6 +10,7 @@ use constant DEVICE_PER_MESSAGE => 4;
 use English qw(-no_match_vars);
 use Net::IP;
 use Time::localtime;
+use Time::HiRes qw(usleep);
 use Thread::Queue v2.01;
 use UNIVERSAL::require;
 use XML::TreePP;
@@ -201,7 +202,7 @@ sub run {
                 my $newthread = threads->create($sub);
                 # Keep known created threads in a hash
                 $running_threads{$newthread->tid()} = $newthread ;
-                delay(0.1) until ($newthread->is_running() || $newthread->is_joinable());
+                usleep(50000) until ($newthread->is_running() || $newthread->is_joinable());
             }
 
             # Check really started threads number vs really running ones
@@ -226,8 +227,8 @@ sub run {
                     $self->{logger}->debug("Sent result #$debug_sent_count");
                 }
 
-                # wait for a second
-                delay(1);
+                # wait for a little
+                usleep(50000);
 
                 # List our created and possibly running threads in a list to check
                 my %our_running_threads_checklist = map { $_ => 0 } keys(%running_threads);

--- a/lib/FusionInventory/Agent/Task/NetDiscovery.pm
+++ b/lib/FusionInventory/Agent/Task/NetDiscovery.pm
@@ -202,7 +202,7 @@ sub run {
             push @all_started_threads, @started_threads ;
 
             # Check really started threads number
-            $self->{logger}->warning(scalar(@started_threads)." really started: [@started_threads]")
+            $self->{logger}->debug(scalar(@started_threads)." really started: [@started_threads]")
                 unless (@started_threads == $threads_count && @threads == $threads_count);
 
             # as long as some threads are still running...

--- a/lib/FusionInventory/Agent/Task/NetInventory.pm
+++ b/lib/FusionInventory/Agent/Task/NetInventory.pm
@@ -153,7 +153,7 @@ sub run {
         my @started_threads = map { $_->tid() } threads->list(threads::running);
 
         # Check really started threads number
-        $self->{logger}->warning(scalar(@started_threads)." really started: [@started_threads]")
+        $self->{logger}->debug(scalar(@started_threads)." really started: [@started_threads]")
             unless (@started_threads == $threads_count && @threads == $threads_count);
 
         # as long as some threads are still running...

--- a/lib/FusionInventory/Agent/Task/NetInventory.pm
+++ b/lib/FusionInventory/Agent/Task/NetInventory.pm
@@ -7,6 +7,7 @@ use base 'FusionInventory::Agent::Task';
 
 use Encode qw(encode);
 use English qw(-no_match_vars);
+use Time::HiRes qw(usleep);
 use Thread::Queue v2.01;
 use UNIVERSAL::require;
 
@@ -154,6 +155,7 @@ sub run {
             my $newthread = threads->create($sub);
             # Keep known created threads in a hash
             $running_threads{$newthread->tid()} = $newthread ;
+            usleep(50000) until ($newthread->is_running() || $newthread->is_joinable());
         }
 
         # Check really started threads number vs really running ones
@@ -176,8 +178,8 @@ sub run {
                 $self->{logger}->debug("Sent result #$debug_sent_count");
             }
 
-            # wait for a second
-            delay(1);
+            # wait for a little
+            usleep(50000);
 
             # List our created and possibly running threads in a list to check
             my %our_running_threads_checklist = map { $_ => 0 } keys(%running_threads);

--- a/lib/FusionInventory/Agent/Task/NetInventory.pm
+++ b/lib/FusionInventory/Agent/Task/NetInventory.pm
@@ -101,6 +101,8 @@ sub run {
         # send initial message to the server
         $self->_sendStartMessage();
 
+        my $debug_sent_count = 0 ;
+
         # initialize FIFOs
         my $devices = Thread::Queue->new();
         my $results = Thread::Queue->new();
@@ -147,32 +149,51 @@ sub run {
         };
 
         $self->{logger}->debug("creating $threads_count worker threads");
-        for (my $i = 0; $i < $threads_count; $i++) {
-            threads->create($sub);
-        }
+        my @threads = map { threads->create($sub) } 1..$threads_count ;
+        my @started_threads = map { $_->tid() } threads->list(threads::running);
+
+        # Check really started threads number
+        $self->{logger}->warning(scalar(@started_threads)." really started: [@started_threads]")
+            unless (@started_threads == $threads_count && @threads == $threads_count);
 
         # as long as some threads are still running...
-        while (threads->list(threads::running)) {
+        while (@threads) {
 
             # send available results on the fly
             while (my $result = $results->dequeue_nb()) {
+                $debug_sent_count ++ ;
+                $self->{logger}->debug("Send result #$debug_sent_count");
                 $self->_sendResultMessage($result);
+                $self->{logger}->debug("Sent result #$debug_sent_count");
             }
 
             # wait for a second
             delay(1);
+
+            # Re-check running threads so it must have been in started list
+            @threads = grep {
+                my $running = $_ ; grep { $running == $_ } @threads
+            } threads->list(threads::running);
         }
 
         # purge remaining results
         while (my $result = $results->dequeue_nb()) {
+            $debug_sent_count ++ ;
+            $self->{logger}->debug("Send result #$debug_sent_count");
             $self->_sendResultMessage($result);
+            $self->{logger}->debug("Sent result #$debug_sent_count");
         }
 
-        $self->{logger}->debug("cleaning $threads_count worker threads");
-        $_->join() foreach threads->list(threads::joinable);
-
-        # send final message to the server
+        # send final message to the server before cleaning threads
         $self->_sendStopMessage();
+
+        if (@started_threads) {
+            $self->{logger}->debug("cleaning $threads_count worker threads");
+            $_->join() foreach threads->list(threads::joinable);
+        }
+
+        $self->{logger}->debug( $debug_sent_count ?
+            "$debug_sent_count results sent" : "No result sent" );
     }
 }
 

--- a/lib/FusionInventory/Agent/Task/NetInventory.pm
+++ b/lib/FusionInventory/Agent/Task/NetInventory.pm
@@ -15,7 +15,7 @@ use FusionInventory::Agent::Tools;
 use FusionInventory::Agent::Tools::Hardware;
 use FusionInventory::Agent::Tools::Network;
 
-our $VERSION = '2.2.0';
+our $VERSION = '2.2.1';
 
 # list of devices properties, indexed by XML element name
 # the link to a specific OID is made by the model
@@ -101,7 +101,8 @@ sub run {
         # send initial message to the server
         $self->_sendStartMessage();
 
-        my $debug_sent_count = 0 ;
+        my ($debug_sent_count, $started_count) = ( 0, 0 );
+        my %running_threads = ();
 
         # initialize FIFOs
         my $devices = Thread::Queue->new();
@@ -149,15 +150,23 @@ sub run {
         };
 
         $self->{logger}->debug("creating $threads_count worker threads");
-        my @threads = map { threads->create($sub) } 1..$threads_count ;
-        my @started_threads = map { $_->tid() } threads->list(threads::running);
+        for (my $i = 0; $i < $threads_count; $i++) {
+            my $newthread = threads->create($sub);
+            # Keep known created threads in a hash
+            $running_threads{$newthread->tid()} = $newthread ;
+        }
 
-        # Check really started threads number
-        $self->{logger}->debug(scalar(@started_threads)." really started: [@started_threads]")
-            unless (@started_threads == $threads_count && @threads == $threads_count);
+        # Check really started threads number vs really running ones
+        my @really_running  = map { $_->tid() } threads->list(threads::running);
+        my @started_threads = keys(%running_threads);
+        unless (@really_running == $threads_count && keys(%running_threads) == $threads_count) {
+            $self->{logger}->debug(scalar(@really_running)." really running: [@really_running]");
+            $self->{logger}->debug(scalar(@started_threads)." started: [@started_threads]");
+        }
+        $started_count += @started_threads ;
 
         # as long as some threads are still running...
-        while (@threads) {
+        while (keys(%running_threads)) {
 
             # send available results on the fly
             while (my $result = $results->dequeue_nb()) {
@@ -170,10 +179,23 @@ sub run {
             # wait for a second
             delay(1);
 
-            # Re-check running threads so it must have been in started list
-            @threads = grep {
-                my $running = $_ ; grep { $running == $_ } @threads
-            } threads->list(threads::running);
+            # List our created and possibly running threads in a list to check
+            my %our_running_threads_checklist = map { $_ => 0 } keys(%running_threads);
+
+            foreach my $running (threads->list(threads::running)) {
+                my $tid = $running->tid();
+                # Skip if this running thread tid is not is our started list
+                next unless exists($running_threads{$tid});
+
+                # Check a thread is still running
+                $our_running_threads_checklist{$tid} = 1 ;
+            }
+
+            # Clean our started list from thread tid that don't run anymore
+            foreach my $tid (keys(%our_running_threads_checklist)) {
+                delete $running_threads{$tid}
+                    unless $our_running_threads_checklist{$tid};
+            }
         }
 
         # purge remaining results
@@ -187,8 +209,8 @@ sub run {
         # send final message to the server before cleaning threads
         $self->_sendStopMessage();
 
-        if (@started_threads) {
-            $self->{logger}->debug("cleaning $threads_count worker threads");
+        if ($started_count) {
+            $self->{logger}->debug("cleaning $started_count worker threads");
             $_->join() foreach threads->list(threads::joinable);
         }
 

--- a/t/apps/netinventory.t
+++ b/t/apps/netinventory.t
@@ -18,7 +18,7 @@ if (!$Config{usethreads} || $Config{usethreads} ne 'define') {
     plan skip_all => 'thread support required';
 }
 
-plan tests => 12;
+plan tests => 15;
 
 FusionInventory::Agent::Task::NetInventory->use();
 
@@ -56,7 +56,7 @@ is($out, '', 'no target stdout');
 
 ($out, $err, $rc) = run_executable(
     'fusioninventory-netinventory',
-    '--file resources/walks/sample4.walk'
+    '--host 127.0.0.1 --file resources/walks/sample4.walk'
 );
 ok($rc == 0, 'success exit status');
 
@@ -69,3 +69,18 @@ $result->{'REQUEST'}{'CONTENT'}{'MODULEVERSION'} =
 $result->{'REQUEST'}{'DEVICEID'} = re('^\S+$');
 
 cmp_deeply($content, $result, "expected output");
+
+# Check multi-threading support
+my $hosts = join(",", map { "127.0.0.$_" } 10..19);
+($out, $err, $rc) = run_executable('fusioninventory-netinventory', "--host $hosts --file resources/walks/sample1.walk --debug --threads 10");
+ok($rc == 0, '10 threads started to scan on loopback');
+like(
+    $out,
+    qr/QUERY.*SNMPQUERY/,
+    'query output'
+);
+like(
+    $err,
+    qr/cleaning 10 worker threads/,
+    'cleaning threads reached'
+);


### PR DESCRIPTION
We had a case with a 2.3.16 windows agent where the thread 1 was still existing (or created but not using the requested sub, I didn't find how this can happen). This involved the task didn't stop as it was blocked waiting for this not related thread number 1. This refactoring only check against really created thread. This was tested on the faulty platform and the net task stopped nicely.