### PR TITLE
Add English module use as this fix unittest failing on Rudder module require() try

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/Generic/Rudder.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Generic/Rudder.pm
@@ -3,6 +3,8 @@ package FusionInventory::Agent::Task::Inventory::Generic::Rudder;
 use strict;
 use warnings;
 
+use English qw(-no_match_vars);
+
 use FusionInventory::Agent::Tools;
 
 sub isEnabled {


### PR DESCRIPTION
use English module in Rudder to avoid failing require() while loaded from fusioninventory-agent apps