### PR TITLE
2.3.x+normalize reported network speed

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/Linux/Networks/FibreChannel.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Linux/Networks/FibreChannel.pm
@@ -51,7 +51,8 @@ sub _getInterfacesFromFcHost {
                 $interface->{'STATUS'} = 'Down';
             }
         } elsif ($line =~ /speed\s+= "(.+)"/) {
-            $interface->{'SPEED'} = $1 if ($1 ne 'unknown');
+            $interface->{'SPEED'} = getCanonicalInterfaceSpeed($1)
+                if ($1 ne 'unknown');
 
             push @interfaces, $interface;
         }

--- a/lib/FusionInventory/Agent/Task/Inventory/Solaris/Networks.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Solaris/Networks.pm
@@ -112,6 +112,7 @@ sub  _getInterfaceSpeed {
         pattern => qr/^\s*link_speed+\s*(\d+)/,
     );
 
+    # By default, kstat reports speed as Mb/s, no need to normalize
     return $speed;
 }
 
@@ -182,7 +183,7 @@ sub _parseDladm {
             $line =~ /(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)/;
         $interface->{DESCRIPTION} = $1;
         $interface->{MACADDR}     = $2;
-        $interface->{SPEED}       = $3 . " " . $4 . " " . $5;
+        $interface->{SPEED}       = getCanonicalInterfaceSpeed($3 . $4);
         $interface->{STATUS}      = 'Up' if $line =~ /UP/;
         push @interfaces, $interface;
     }
@@ -203,7 +204,7 @@ sub _parsefcinfo {
             if $line =~ /HBA Port WWN:\s+(\S+)/;
         $interface->{DESCRIPTION} .= " " . $1
             if $line =~ /OS Device Name:\s+(\S+)/;
-        $interface->{SPEED} = $1
+        $interface->{SPEED} = getCanonicalInterfaceSpeed($1)
             if $line =~ /Current Speed:\s+(\S+)/;
         $interface->{WWN} = $1
             if $line =~ /Node WWN:\s+(\S+)/;

--- a/lib/FusionInventory/Agent/Tools.pm
+++ b/lib/FusionInventory/Agent/Tools.pm
@@ -21,6 +21,7 @@ our @EXPORT = qw(
     getFormatedDate
     getCanonicalManufacturer
     getCanonicalSpeed
+    getCanonicalInterfaceSpeed
     getCanonicalSize
     getSanitizedString
     trimWhitespace
@@ -147,6 +148,25 @@ sub getCanonicalSpeed {
         $unit eq 'ghz' ? $value * 1000 :
         $unit eq 'mhz' ? $value        :
                          undef         ;
+}
+
+sub getCanonicalInterfaceSpeed {
+    # Expected unit is Mb/s as specified in inventory protocol
+    my ($speed) = @_;
+
+    ## no critic (ExplicitReturnUndef)
+
+    return undef unless $speed;
+
+    return undef unless $speed =~ /^([,.\d]+) \s? (\S\S)\S*$/x;
+    my $value = $1;
+    my $unit = lc($2);
+
+    return
+        $unit eq 'gb' ? $value * 1000         :
+        $unit eq 'mb' ? $value                :
+        $unit eq 'kb' ? int($value / 1000)    :
+                        undef                 ;
 }
 
 sub getCanonicalSize {
@@ -539,6 +559,10 @@ Returns a normalized manufacturer value for given one.
 =head2 getCanonicalSpeed($speed)
 
 Returns a normalized speed value (in Mhz) for given one.
+
+=head2 getCanonicalInterfaceSpeed($speed)
+
+Returns a normalized network interface speed value (in Mb/s) for given one.
 
 =head2 getCanonicalSize($size, $base)
 

--- a/resources/solaris/fcinfo_hba-port/sample-2
+++ b/resources/solaris/fcinfo_hba-port/sample-2
@@ -1,0 +1,42 @@
+HBA Port WWN: 230000144f3eb274
+        OS Device Name: /dev/cfg/c1
+        Manufacturer: QLogic Corp.
+        Model: 2200
+        Firmware Version: 02.01.145
+        FCode/BIOS Version: ISP2200 FC-AL Host Adapter Driver: 1.15 04/03/22
+        Serial Number: not available
+        Driver Name: qlc
+        Driver Version: 20110321-3.05
+        Type: L-port
+        State: online
+        Supported Speeds: 1Gb
+        Current Speed: 1Gb
+        Node WWN: 220000144f3eb274
+HBA Port WWN: 210000e08b90682c
+        OS Device Name: /dev/cfg/c2
+        Manufacturer: QLogic Corp.
+        Model: QLA2340
+        Firmware Version: 03.03.28
+        FCode/BIOS Version:  fcode: 1.13;
+        Serial Number: not available
+        Driver Name: qlc
+        Driver Version: 20110321-3.05
+        Type: N-port
+        State: online
+        Supported Speeds: 1Gb 2Gb
+        Current Speed: 2Gb
+        Node WWN: 200000e08b90682c
+HBA Port WWN: 210000e08b90b82b
+        OS Device Name: /dev/cfg/c3
+        Manufacturer: QLogic Corp.
+        Model: QLA2340
+        Firmware Version: 03.03.28
+        FCode/BIOS Version:  fcode: 1.13;
+        Serial Number: not available
+        Driver Name: qlc
+        Driver Version: 20110321-3.05
+        Type: unknown
+        State: offline
+        Supported Speeds: 1Gb 2Gb
+        Current Speed: not established
+        Node WWN: 200000e08b90b82b

--- a/t/tasks/inventory/linux/networks/fibrechannel.t
+++ b/t/tasks/inventory/linux/networks/fibrechannel.t
@@ -16,14 +16,14 @@ my %tests = (
     'sample1' => [
         {
             STATUS      => 'Up',
-            SPEED       => '4 Gbit',
+            SPEED       => '4000',
             TYPE        => 'fibrechannel',
             DESCRIPTION => 'host5',
             WWN         => '10:00:00:00:c9:af:df:c6',
         },
         {
             STATUS      => 'Up',
-            SPEED       => '4 Gbit',
+            SPEED       => '4000',
             TYPE        => 'fibrechannel',
             DESCRIPTION => 'host6',
             WWN         => '10:00:00:00:c9:af:df:c7',


### PR DESCRIPTION
We should normalize the reported network interface speed value when it can be as Mbits/s like specified here:
http://www.fusioninventory.org/documentation/dev/spec/protocol/inventory/
...
      <!-- interface speed, in Mb/s -->
      <!ELEMENT SPEED (#PCDATA)>
...