### PR TITLE
2.3.x+check fix

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/Virtualization/Vmsystem.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Virtualization/Vmsystem.pm
@@ -65,7 +65,7 @@ sub doInventory {
     # for consistency with HVM domU
     if (
         $type eq 'Xen' &&
-        !$inventory->{h}{CONTENT}{BIOS}{SMANUFACTURER}
+        !$inventory->{content}{BIOS}{SMANUFACTURER}
     ) {
         $inventory->setBios({
             SMANUFACTURER => 'Xen',

--- a/lib/FusionInventory/Agent/Task/Inventory/Virtualization/Vmsystem.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Virtualization/Vmsystem.pm
@@ -60,13 +60,10 @@ sub doInventory {
     my $inventory = $params{inventory};
     my $logger    = $params{logger};
 
-    my $type = _getType($inventory->{content}->{BIOS}, $logger);
+    my $type = _getType($inventory->getSection('BIOS'), $logger);
 
     # for consistency with HVM domU
-    if (
-        $type eq 'Xen' &&
-        !$inventory->{content}{BIOS}{SMANUFACTURER}
-    ) {
+    if ($type eq 'Xen' && !$inventory->getBios('SMANUFACTURER')) {
         $inventory->setBios({
             SMANUFACTURER => 'Xen',
             SMODEL => 'PVM domU'


### PR DESCRIPTION
This PR extends PR #53 as I don't see why we are doing a check against ->{h}{CONTENT} where this hash value should not be available.