### PR TITLE
Update CPU.pm

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/AIX/CPU.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/AIX/CPU.pm
@@ -18,7 +18,7 @@ sub doInventory {
     my $logger    = $params{logger};
 
     foreach my $cpu (_getCPUs(
-        command => 'lsdev -Cc processor -F name',
+        command => 'lsdev -Cc processor |grep Available |cut -d " " -f1', # Catch only available processors
         logger  => $logger
     )) {
         $inventory->addEntry(


### PR DESCRIPTION
lsdev command curently catching all processors even if they're not installed (PowerPC POWER5 and PowerPC POWER6  displayed on GLPI for the same server).
So, to only catch active processors, we grep on "Available" processors.