### PR TITLE
2.3.x bug do split only on scalar

### DIFF
--- a/lib/FusionInventory/Agent/Config.pm
+++ b/lib/FusionInventory/Agent/Config.pm
@@ -255,7 +255,9 @@ sub _checkContent {
             no-category
             /) {
 
-        if ($self->{$option}) {
+        # Check if defined AND SCALAR
+        # to avoid split a ARRAY ref or HASH ref...
+        if ($self->{$option} && ref($self->{$option}) eq '') {
             $self->{$option} = [split(/,/, $self->{$option})];
         } else {
             $self->{$option} = [];

--- a/lib/FusionInventory/Agent/Config.pm
+++ b/lib/FusionInventory/Agent/Config.pm
@@ -42,10 +42,6 @@ my $default = {
     'user'                    => undef,
     # deprecated options
     'stdout'                  => undef,
-    # multi-values options that will be converted to array ref
-    'httpd-trust'             => "",
-    'no-task'                 => "",
-    'no-category'             => ""
 };
 
 my $deprecated = {


### PR DESCRIPTION
Hello,

When split is used on other value than scalar like array ref or hash ref, it gives results... but these results are not expected. 
With this fix, removing duplicate keys can be done.

Regards.