### PR TITLE
Fix : when using glob function with strings containing spaces, string…

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/MacOS/License.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/MacOS/License.pm
@@ -24,7 +24,7 @@ sub doInventory {
     );
 
     # Transmit
-    my @transmitFiles = glob('/System/Library/User Template/*.lproj/Library/Preferences/com.panic.Transmit.plist');
+    my @transmitFiles = glob('"/System/Library/User Template/*.lproj/Library/Preferences/com.panic.Transmit.plist"');
 
     if ($params{scan_homedirs}) {
         push @transmitFiles, glob('/Users/*/Library/Preferences/com.panic.Transmit.plist');
@@ -45,7 +45,7 @@ sub doInventory {
     }
 
     # VMware
-    my @vmwareFiles = glob('/Library/Application Support/VMware Fusion/license-*');
+    my @vmwareFiles = glob('"/Library/Application Support/VMware Fusion/license-*"');
     foreach my $vmwareFile (@vmwareFiles) {
         my %info;
         # e.g:


### PR DESCRIPTION
…s must be enclosed with double quotes.

Example :
Without double quotes, the string '/System/Library/User Template/' will be splitted in two strings :
- '/System/Library/User'
- 'Template/'
In these case, this is not the expected behavior because we want the glob function to consider the path '/System/Library/User Template/'.