### PR TITLE
New feature : tasks execution plan

### DIFF
--- a/bin/fusioninventory-agent
+++ b/bin/fusioninventory-agent
@@ -52,6 +52,7 @@ GetOptions(
     'scan-profiles',
     'server|s=s',
     'tag|t=s',
+    'tasks=s',
     'timeout=i',
     'user|u=s',
     'version',
@@ -97,9 +98,20 @@ my $agent = FusionInventory::Agent->new(%setup);
 
 if ($options->{'list-tasks'}) {
     my %tasks = $agent->getAvailableTasks();
+    print "Available tasks : \n";
     foreach my $task (keys %tasks) {
         print "$task (v$tasks{$task})\n";
     }
+
+    if ($options->{'tasks'}) {
+        $agent->init(options => $options);
+        my $tasksExecutionPlan = $agent->getTasksExecutionPlan();
+        print "\nTasks planned for execution : \n";
+        foreach my $task (@$tasksExecutionPlan) {
+            print "$task (v$tasks{$task})\n";
+        }
+    }
+
     exit 0;
 }
 
@@ -288,7 +300,7 @@ This option is only available when the agent is not run as a server.
 
 =item B<--list-tasks>
 
-List available tasks and exit
+List all available tasks, tasks planned for execution and exit
 
 =item B<--no-task>=I<TASK>
 

--- a/etc/agent.cfg
+++ b/etc/agent.cfg
@@ -21,6 +21,7 @@
 
 # disable software deployment tasks
 #no-task = deploy
+#tasks = inventory, deploy, inventory,...
 
 #
 # Target scheduling options

--- a/lib/FusionInventory/Agent/Config.pm
+++ b/lib/FusionInventory/Agent/Config.pm
@@ -8,6 +8,8 @@ use File::Spec;
 use Getopt::Long;
 use UNIVERSAL::require;
 
+require FusionInventory::Agent::Tools;
+
 my $default = {
     'additional-content'      => undef,
     'backend-collect-timeout' => 180,
@@ -38,6 +40,7 @@ my $default = {
     'scan-profiles'           => undef,
     'server'                  => undef,
     'tag'                     => undef,
+    'tasks'                   => undef,
     'timeout'                 => 180,
     'user'                    => undef,
     # deprecated options
@@ -253,6 +256,7 @@ sub _checkContent {
             httpd-trust
             no-task
             no-category
+            tasks
             /) {
 
         if ($self->{$option}) {
@@ -269,6 +273,12 @@ sub _checkContent {
         File::Spec->rel2abs($self->{'ca-cert-dir'}) if $self->{'ca-cert-dir'};
     $self->{'logfile'} =
         File::Spec->rel2abs($self->{'logfile'}) if $self->{'logfile'};
+}
+
+sub isParamArrayAndFilled {
+    my ($self, $paramName) = @_;
+
+    return FusionInventory::Agent::Tools::isParamArrayAndFilled($self, $paramName);
 }
 
 1;

--- a/lib/FusionInventory/Agent/Tools.pm
+++ b/lib/FusionInventory/Agent/Tools.pm
@@ -44,6 +44,7 @@ our @EXPORT = qw(
     runFunction
     delay
     slurp
+    isParamArrayAndFilled
 );
 
 my $nowhere = $OSNAME eq 'MSWin32' ? 'nul' : '/dev/null';
@@ -527,6 +528,14 @@ sub slurp {
     return $content;
 }
 
+sub isParamArrayAndFilled {
+    my ($hash, $paramName) = @_;
+    
+    return (defined ($hash->{$paramName}))
+            && UNIVERSAL::isa($hash->{$paramName}, 'ARRAY')
+            && (scalar(@{$hash->{$paramName}}) > 0);
+}
+
 1;
 __END__
 
@@ -767,3 +776,7 @@ on the Operating System.
 =head2 slurp($file)
 
 Return the content of a given file.
+
+=head2 isParamArrayAndFilled($hash, $paramName)
+
+Return if $hash has a key $paramName which value is a ARRAY ref not empty.

--- a/resources/config/sample4
+++ b/resources/config/sample4
@@ -1,4 +1,4 @@
 #no-inventory=1
-no-task=snmpquery,wakeonlan
+no-task=snmpquery,wakeonlan,inventory
 #no-software=1
 tasks=inventory, deploy , inventory

--- a/t/agent/agent.t
+++ b/t/agent/agent.t
@@ -10,7 +10,7 @@ use Test::More;
 
 use FusionInventory::Agent;
 
-plan tests => 4;
+plan tests => 5 + 19;
 
 my $libdir = tempdir(CLEANUP => $ENV{TEST_DEBUG} ? 0 : 1);
 push @INC, $libdir;
@@ -75,6 +75,46 @@ cmp_deeply(
     "wrong class"
 );
 
+create_file("$libdir/FusionInventory/Agent/Task", "Task5.pm", <<'EOF');
+package FusionInventory::Agent::Task::Task5;
+use base qw(FusionInventory::Agent::Task);
+our $VERSION = 42;
+EOF
+%tasks = $agent->getAvailableTasks();
+cmp_deeply (
+    \%tasks,
+    {
+        'Task1' => 42,
+        'Task2' => 42,
+        'Task5' => 42
+    },
+    "multiple tasks"
+);
+
+$agent->{config} = FusionInventory::Agent::Config->new(
+    (
+        confdir => 'etc'
+    )
+);
+$agent->{config}->{'no-task'} = ['Task5'];
+$agent->{config}->{'tasks'} = ['Task1', 'Task5', 'Task1', 'Task5', 'Task5', 'Task2', 'Task1'];
+my %availableTasks = $agent->getAvailableTasks(disabledTasks => $agent->{config}->{'no-task'});
+my $logger = FusionInventory::Agent::Logger->new(
+    backends  => ['File'],
+);
+$agent->{logger} = $logger;
+my @plan = $agent->computeTaskExecutionPlan(keys %availableTasks);
+my $expectedPlan = [
+    'Task1',
+    'Task1',
+    'Task2',
+    'Task1'
+];
+cmp_deeply(
+    \@plan,
+    $expectedPlan
+);
+
 sub create_file {
     my ($directory, $file, $content) = @_;
 
@@ -85,3 +125,130 @@ sub create_file {
     print $fh $content;
     close $fh;
 }
+
+my $list1 = [
+    'elem1',
+    'elem2',
+    'elem3',
+    'elem4'
+];
+my $list2 = [
+    'elem5',
+    'elem2',
+    'elem1',
+    'elem5',
+    'elem2',
+    'elem6',
+    'elem1'
+];
+my $wanted = [
+    'elem1',
+    'elem2',
+    'elem3',
+    'elem4'
+];
+my @list3 = FusionInventory::Agent::_appendElementsNotAlreadyInList($list1, $list2);
+my $i = 0;
+while ($i < 4) {
+    ok( $list3[$i] eq $wanted->[$i]);
+    $i++;
+}
+my @otherElements = @list3[4..$#list3];
+ok( scalar( @otherElements) == 2);
+my %otherElements = map { $_ => 1 } @list3[4..$#list3];
+ok (defined( $otherElements{'elem5'}));
+ok (defined( $otherElements{'elem6'}));
+
+my @tasks = (
+    'task1',
+    'task2',
+    'taskwithoutanumber',
+    'task345'
+);
+my @tasksInConf = (
+    'task1',
+    'task2',
+    'task1',
+    'task3',
+    'task3'
+);
+my @tasksExecutionPlan = FusionInventory::Agent::_makeExecutionPlan(\@tasksInConf, @tasks);
+my @expectedExecutionPlan = (
+    'task1',
+    'task2',
+    'task1'
+);
+cmp_deeply(
+    \@tasksExecutionPlan,
+    \@expectedExecutionPlan
+);
+my $ok = 0;
+$i = 0;
+while ($i < scalar(@expectedExecutionPlan)) {
+    $ok = ( defined( $tasksExecutionPlan[$i] ) && ( $expectedExecutionPlan[$i] eq $tasksExecutionPlan[$i] ) );
+    if (! $ok) {
+        last;
+    }
+    $i++;
+}
+ok ($ok);
+
+@tasksInConf = (
+    'task1',
+    'task2',
+    'task1',
+    'task3',
+    'task3',
+    'task3',
+    'task5',
+    'task1',
+    'task2',
+    'task2'
+);
+@tasksExecutionPlan = FusionInventory::Agent::_makeExecutionPlan(\@tasksInConf, @tasks);
+@expectedExecutionPlan = (
+    'task1',
+    'task2',
+    'task1',
+    'task1',
+    'task2',
+    'task2'
+);
+cmp_deeply(
+    \@tasksExecutionPlan,
+    \@expectedExecutionPlan
+);
+
+@tasksInConf = (
+    'task1',
+    'task2',
+    'task1',
+    'task3',
+    'task3',
+    'task3',
+    'task5',
+    'task1',
+    'task2',
+    'task2',
+    '...'
+);
+@tasksExecutionPlan = FusionInventory::Agent::_makeExecutionPlan(\@tasksInConf, @tasks);
+# the first part of execution plan, the ordered part
+my @expectedExecutionPlanOrderedPart = (
+    'task1',
+    'task2',
+    'task1',
+    'task1',
+    'task2',
+    'task2',
+);
+$i = 0;
+while ( $i < 6) {
+    ok( $tasksExecutionPlan[$i] eq $expectedExecutionPlanOrderedPart[$i]);
+    $i++;
+}
+ok (scalar(@tasksExecutionPlan) == 8);
+ok (
+    ($tasksExecutionPlan[6] eq 'taskwithoutanumber' && $tasksExecutionPlan[7] eq 'task345')
+    || ($tasksExecutionPlan[7] eq 'taskwithoutanumber' && $tasksExecutionPlan[6] eq 'task345')
+);

--- a/t/agent/config.t
+++ b/t/agent/config.t
@@ -12,7 +12,8 @@ my %config = (
     sample1 => {
         'no-task'     => ['snmpquery', 'wakeonlan'],
         'no-category' => [],
-        'httpd-trust' => []
+        'httpd-trust' => [],
+        'tasks'       => ['inventory', 'deploy', 'inventory']
     },
     sample2 => {
         'no-task'     => [],
@@ -23,11 +24,16 @@ my %config = (
         'no-task'     => [],
         'no-category' => [],
         'httpd-trust' => []
+    },
+    sample4 => {
+        'no-task'     => ['snmpquery','wakeonlan','inventory'],
+        'no-category' => [],
+        'httpd-trust' => [],
+        'tasks'       => ['inventory', 'deploy', 'inventory']
     }
-
 );
 
-plan tests => (scalar keys %config) * 3;
+plan tests => (scalar keys %config) * 3 + 16;
 
 foreach my $test (keys %config) {
     my $c = FusionInventory::Agent::Config->new(options => {
@@ -36,5 +42,27 @@ foreach my $test (keys %config) {
 
     foreach my $k (qw/ no-task no-category httpd-trust /) {
         cmp_deeply($c->{$k}, $config{$test}->{$k}, $test." ".$k);
+    }
+
+    if ($test eq 'sample1') {
+        ok ($c->isParamArrayAndFilled('no-task'));
+        ok (! $c->isParamArrayAndFilled('no-category'));
+        ok (! $c->isParamArrayAndFilled('httpd-trust'));
+        ok ($c->isParamArrayAndFilled('tasks'));
+    } elsif ($test eq 'sample2') {
+        ok (! $c->isParamArrayAndFilled('no-task'));
+        ok ($c->isParamArrayAndFilled('no-category'));
+        ok ($c->isParamArrayAndFilled('httpd-trust'));
+        ok (! $c->isParamArrayAndFilled('tasks'));
+    } elsif ($test eq 'sample3') {
+        ok (! $c->isParamArrayAndFilled('no-task'));
+        ok (! $c->isParamArrayAndFilled('no-category'));
+        ok (! $c->isParamArrayAndFilled('httpd-trust'));
+        ok (! $c->isParamArrayAndFilled('tasks'));
+    } elsif ($test eq 'sample4') {
+        ok ($c->isParamArrayAndFilled('no-task'));
+        ok (! $c->isParamArrayAndFilled('no-category'));
+        ok (! $c->isParamArrayAndFilled('httpd-trust'));
+        ok ($c->isParamArrayAndFilled('tasks'));
     }
 }


### PR DESCRIPTION
New feature : tasks execution plan.
Parameter 'tasks' can be filled for example like this : task1,task2,task3
Only these tasks will be executed. If there is at the end of the list the word '...', all available tasks not executed yet will be executed.
Examples :

--tasks=task1,task2,task1 Executes task1, task2, task1 and then stops.
--tasks=task1,task2,task1,... Executes task1, task2, task1 and then all other available tasks.
