### PR TITLE
2.3.x bug tasks execution plan lost when config reload

### DIFF
--- a/lib/FusionInventory/Agent.pm
+++ b/lib/FusionInventory/Agent.pm
@@ -115,8 +115,8 @@ sub init {
     }
     $logger->debug("Planned tasks:");
     foreach my $task (@{$self->{tasksExecutionPlan}}) {
-        $task = lc $task;
-        $logger->debug("- $task: " . $available{$available_lc{$task}});
+        my $task_lc = lc $task;
+        $logger->debug("- $task: " . $available{$available_lc{$task_lc}});
     }
 
     $self->{tasks} = \@tasks;
@@ -572,16 +572,16 @@ sub _makeExecutionPlan {
 
     my $sortedTasksCloned = dclone $sortedTasks;
     my @executionPlan = ();
-    my %available = map { (lc $_) => 1 } @$availableTasksNames;
+    my %available = map { (lc $_) => $_ } @$availableTasksNames;
 
     my $task = shift @$sortedTasksCloned;
     while (defined $task) {
-        $task = lc $task;
         if ($task eq $CONTINUE_WORD) {
             last;
         }
+        $task = lc $task;
         if ( defined($available{$task})) {
-            push @executionPlan, $task;
+            push @executionPlan, $available{$task};
         }
         $task = shift @$sortedTasksCloned;
     }

--- a/lib/FusionInventory/Agent.pm
+++ b/lib/FusionInventory/Agent.pm
@@ -103,6 +103,7 @@ sub init {
     my @plannedTasks = $self->computeTaskExecutionPlan(\@tasks);
     $self->{tasksExecutionPlan} = \@plannedTasks;
 
+    my %available_lc = map { (lc $_) => $_ } keys %available;
     if (!@tasks) {
         $logger->error("No tasks available, aborting");
         exit 1;
@@ -114,7 +115,8 @@ sub init {
     }
     $logger->debug("Planned tasks:");
     foreach my $task (@{$self->{tasksExecutionPlan}}) {
-        $logger->debug("- $task: $available{$task}");
+        $task = lc $task;
+        $logger->debug("- $task: " . $available{$available_lc{$task}});
     }
 
     $self->{tasks} = \@tasks;
@@ -188,6 +190,7 @@ sub reinit {
     my @plannedTasks = $self->computeTaskExecutionPlan(\@tasks);
     $self->{tasksExecutionPlan} = \@plannedTasks;
 
+    my %available_lc = map { (lc $_) => $_ } keys %available;
     if (!@tasks) {
         $logger->error("No tasks available, aborting");
         exit 1;
@@ -199,7 +202,8 @@ sub reinit {
     }
     $logger->debug("Planned tasks:");
     foreach my $task (@{$self->{tasksExecutionPlan}}) {
-        $logger->debug("- $task: $available{$task}");
+        $task = lc $task;
+        $logger->debug("- $task: " . $available{$available_lc{$task}});
     }
 
     $self->{tasks} = \@tasks;

--- a/t/agent/agent.t
+++ b/t/agent/agent.t
@@ -12,7 +12,7 @@ use Test::More;
 use FusionInventory::Agent;
 use FusionInventory::Agent::Config;
 
-plan tests => 5 + 19 + 11;
+plan tests => 5 + 19 + 11 + 1;
 
 my $libdir = tempdir(CLEANUP => $ENV{TEST_DEBUG} ? 0 : 1);
 push @INC, $libdir;
@@ -313,3 +313,35 @@ SKIP: {
     ok ($agent->{config}->{$testKey} eq $keyInitialValue);
 }
 
+
+@tasks = (
+    'Task1',
+    'Task2',
+    'Taskwithoutanumber',
+    'Task345'
+);
+@tasksInConf = (
+    'task1',
+    'task2',
+    'task1',
+    'task3',
+    'task3',
+    'task3',
+    'task5',
+    'task1',
+    'task2',
+    'task2'
+);
+@tasksExecutionPlan = FusionInventory::Agent::_makeExecutionPlan(\@tasksInConf, \@tasks);
+@expectedExecutionPlan = (
+    'Task1',
+    'Task2',
+    'Task1',
+    'Task1',
+    'Task2',
+    'Task2'
+);
+cmp_deeply(
+    \@tasksExecutionPlan,
+    \@expectedExecutionPlan
+);


### PR DESCRIPTION
Fix
When merging 2.3.x branch with conf reload feature branch, the computation of tasks execution plan were not copied in new reinit() method. So the tasks execution plan was lost after conf reloading...
Now fixed.