### PR TITLE
2.3.x+use perl threading to avoid crash under win32

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -56,6 +56,7 @@ test_requires 'LWP::Protocol::https'         => '0';
 test_requires 'Test::MockObject'             => '0';
 test_requires 'JSON'                         => '0';
 test_requires 'Net::SNMP'                    => '0';
+test_requires 'Parallel::ForkManager'        => '0';
 
 # Inventory
 recommends 'Parse::EDID' => '0';

--- a/bin/fusioninventory-agent
+++ b/bin/fusioninventory-agent
@@ -60,6 +60,8 @@ GetOptions(
     'wait|w=s',
     # deprecated options
     'stdout',
+    # Platform specific option
+    'no-win32-ole-workaround'
 ) or pod2usage(-verbose => 0);
 
 pod2usage(-verbose => 0, -exitstatus => 0) if $options->{help};
@@ -93,6 +95,12 @@ if ($options->{'conf-file'}) {
     } else {
         $options->{config} = 'file';
     }
+}
+
+if ($OSNAME eq 'MSWin32' && ! $options->{'no_worker_thread'}) {
+    # From here we may need to avoid crashes due to not thread-safe Win32::OLE
+    FusionInventory::Agent::Tools::Win32->require();
+    FusionInventory::Agent::Tools::Win32::start_Win32_OLE_Worker();
 }
 
 my $agent = FusionInventory::Agent->new(%setup);
@@ -213,6 +221,10 @@ B<fusioninventory-agent> [options] [--server server|--local path]
     --setup                        print the agent setup directories
                                      and exit
     --version                      print the version and exit
+    --no-win32-ole-workaround      [win32 only] disable win32 work-around
+                                     used to better handle Win32::OLE apis.
+                                     !!! Use it at your own risk as you may
+                                     experiment perl crash under win32 !!!
 
 =head1 DESCRIPTION
 

--- a/bin/fusioninventory-agent
+++ b/bin/fusioninventory-agent
@@ -97,7 +97,7 @@ if ($options->{'conf-file'}) {
     }
 }
 
-if ($OSNAME eq 'MSWin32' && ! $options->{'no_worker_thread'}) {
+if ($OSNAME eq 'MSWin32' && ! $options->{'no-win32-ole-workaround'}) {
     # From here we may need to avoid crashes due to not thread-safe Win32::OLE
     FusionInventory::Agent::Tools::Win32->require();
     FusionInventory::Agent::Tools::Win32::start_Win32_OLE_Worker();

--- a/bin/fusioninventory-win32-service
+++ b/bin/fusioninventory-win32-service
@@ -124,6 +124,11 @@ sub cb_start {
     my( $event, $agent ) = @_;
 
     if (!exists($agent->{agent_thread})) {
+
+        # First start a thread dedicated to Win32::OLE calls
+        FusionInventory::Agent::Tools::Win32->require();
+        FusionInventory::Agent::Tools::Win32::start_Win32_OLE_Worker();
+
         $agent->{agent_thread} = threads->create(sub {
             $agent->init(options => { service => 1 });
             $agent->run();

--- a/lib/FusionInventory/Agent/Tools/Win32.pm
+++ b/lib/FusionInventory/Agent/Tools/Win32.pm
@@ -5,17 +5,21 @@ use warnings;
 use base 'Exporter';
 use utf8;
 
+use threads;
+use threads 'exit' => 'threads_only';
+use threads::shared;
+
+use UNIVERSAL::require();
+
 use constant KEY_WOW64_64 => 0x100;
 use constant KEY_WOW64_32 => 0x200;
 
 use Cwd;
 use Encode;
 use English qw(-no_match_vars);
+use Memoize;
 use File::Temp qw(:seekable tempfile);
-use Win32::API;
 use Win32::Job;
-use Win32::OLE qw(in);
-use Win32::OLE::Const;
 use Win32::TieRegistry (
     Delimiter   => '/',
     ArrayValues => 0,
@@ -25,21 +29,7 @@ use Win32::TieRegistry (
 use FusionInventory::Agent::Tools;
 use FusionInventory::Agent::Tools::Network;
 
-BEGIN {
-    # As in FusionInventory::Agent::Tools::Hostname
-    if ($OSNAME eq 'MSWin32') {
-        no warnings 'redefine'; ## no critic (ProhibitNoWarnings)
-        Win32::API->require();
-        # Kernel32.dll is used more or less everywhere.
-        # Without this, Win32::API will release the DLL even
-        # if it's a very bad idea
-        *Win32::API::DESTROY = sub {};
-    }
-}
-
-Win32::OLE->Option(CP => Win32::OLE::CP_UTF8);
-
-my $localCodepage;
+memoize('getLocalCodepage');
 
 our @EXPORT = qw(
     is64bit
@@ -56,6 +46,16 @@ our @EXPORT = qw(
 );
 
 sub is64bit {
+    my $win32_ole_dependent_api = {
+        use   => [qw(any)],
+        funct => '_is64bit',
+        args  => \@_
+    };
+
+    return _call_win32_ole_dependent_api($win32_ole_dependent_api);
+}
+
+sub _is64bit {
     return
         any { $_->{AddressWidth} eq 64 }
         getWMIObjects(
@@ -64,15 +64,10 @@ sub is64bit {
 }
 
 sub getLocalCodepage {
-    if (!$localCodepage) {
-        $localCodepage =
-            "cp" .
+    return "cp" .
             getRegistryValue(
                 path => 'HKEY_LOCAL_MACHINE/SYSTEM/CurrentControlSet/Control/Nls/CodePage/ACP'
             );
-    }
-
-    return $localCodepage;
 }
 
 sub encodeFromRegistry {
@@ -87,13 +82,24 @@ sub encodeFromRegistry {
 }
 
 sub getWMIObjects {
+    my $win32_ole_dependent_api = {
+        use   => [qw(in GetObject)],
+        array => 1,
+        funct => '_getWMIObjects',
+        args  => \@_
+    };
+
+    return _call_win32_ole_dependent_api($win32_ole_dependent_api);
+}
+
+sub _getWMIObjects {
     my (%params) = (
         moniker => 'winmgmts:{impersonationLevel=impersonate,(security)}!//./',
         @_
     );
 
     my $WMIService = Win32::OLE->GetObject($params{moniker})
-        or return; #die "WMI connection failed: " . Win32::OLE->LastError();
+        or return;
 
     my @objects;
     foreach my $instance (in(
@@ -386,17 +392,147 @@ sub FileTimeToSystemTime {
 
     my $SystemTime = pack( 'SSSSSSSS', 0, 0, 0, 0, 0, 0, 0, 0 );
 
-    my $FileTimeToSystemTime = Win32::API->new(
-        'kernel32',
-        'FileTimeToSystemTime',
-        [ 'P', 'P' ],
-        'I'
-    );
+    # Load Win32::API as late as possible
+    Win32::API->require() or return;
 
-    $FileTimeToSystemTime->Call( $time, $SystemTime );
-    my @times = unpack( 'SSSSSSSS', $SystemTime );
+    my @times;
+    eval {
+        my $FileTimeToSystemTime = Win32::API->new(
+            'kernel32',
+            'FileTimeToSystemTime',
+            [ 'P', 'P' ],
+            'I'
+        );
+
+        $FileTimeToSystemTime->Call( $time, $SystemTime );
+        @times = unpack( 'SSSSSSSS', $SystemTime );
+    };
 
     return @times;
+}
+
+my $worker ;
+my $worker_semaphore;
+
+my @win32_ole_calls : shared;
+
+sub start_Win32_OLE_Worker {
+
+    unless (defined($worker)) {
+        # Request a semaphore on which worker blocks immediatly
+        Thread::Semaphore->require();
+        $worker_semaphore = Thread::Semaphore->new(0);
+
+        # Start a worker thread
+        $worker = threads->create( \&_win32_ole_worker );
+    }
+}
+
+sub _win32_ole_worker {
+    # Load Win32::OLE as late as possible in a dedicated worker
+    Win32::OLE->require() or return;
+    Win32::OLE->Option(CP => Win32::OLE::CP_UTF8());
+
+    while (1) {
+        # Always block until semaphore is made available by main thread
+        $worker_semaphore->down();
+
+        my ($call, $result);
+        {
+            lock(@win32_ole_calls);
+            $call = shift @win32_ole_calls
+                if (@win32_ole_calls);
+        }
+
+        if (defined($call)) {
+            lock($call);
+
+            # Use all requested API
+            while (my $api = shift @{$call->{'use'}}) {
+                Win32::OLE->use($api);
+            }
+
+            # Found requested private function and call it as expected
+            my $funct;
+            eval {
+                no strict 'refs'; ## no critic (ProhibitNoStrict)
+                $funct = \&{$call->{'funct'}};
+            };
+            if (exists($call->{'array'}) && $call->{'array'}) {
+                my @results = &{$funct}(@{$call->{'args'}});
+                $result = \@results;
+            } else {
+                $result = &{$funct}(@{$call->{'args'}});
+            }
+
+            # Share back the result
+            $call->{'result'} = shared_clone($result);
+
+            # Signal main thread result is available
+            cond_signal($call);
+        }
+    }
+}
+
+sub _call_win32_ole_dependent_api {
+    my ($call) = @_
+        or return;
+
+    if (defined($worker)) {
+        # Share the expect call
+        my $call = shared_clone($call);
+        my $result;
+
+        if (defined($call)) {
+            # Be sure the worker block
+            $worker_semaphore->down_nb();
+
+            # Lock list calls before releasing semaphore so worker waits
+            # on it until we start cond_timedwait for signal on $call
+            lock(@win32_ole_calls);
+            push @win32_ole_calls, $call;
+
+            # Release semaphore so the worker can continue its job
+            $worker_semaphore->up();
+
+            # Now, wait for worker result with one minute timeout
+            my $timeout = time + 60;
+            while (!exists($call->{'result'})) {
+                last if (!cond_timedwait($call, $timeout, @win32_ole_calls));
+            }
+
+            # Be sure to always block worker on semaphore from now
+            $worker_semaphore->down_nb();
+
+            if (exists($call->{'result'})) {
+                $result = $call->{'result'};
+            } else {
+                # Worker is failing: get back to mono-thread and pray
+                $worker->detach();
+                $worker = undef;
+                return _call_win32_ole_dependent_api(@_);
+            }
+        }
+
+        return (exists($call->{'array'}) && $call->{'array'}) ?
+            @{$result || []} : $result ;
+    } else {
+        # We come here from worker or if we failed to start worker
+        foreach my $api (@{$call->{'use'}}) {
+            Win32::OLE->use($api);
+        }
+        my $funct;
+        eval {
+            no strict 'refs'; ## no critic (ProhibitNoStrict)
+            $funct = \&{$call->{'funct'}};
+        };
+        return &{$funct}(@{$call->{'args'}});
+    }
+}
+
+END {
+    # Just detach worker
+    $worker->detach() if (defined($worker) && !$worker->is_detached());
 }
 
 1;
@@ -496,3 +632,9 @@ Returns the list of network interfaces.
 
 Returns an array of a converted FILETIME datetime value with following order:
     ( year, month, wday, day, hour, minute, second, msecond )
+
+=head2 start_Win32_OLE_Worker()
+
+Under win32, just start a worker thread handling Win32::OLE dependent
+APIs like is64bit() & getWMIObjects(). This is sometime needed to avoid
+perl crashes.

--- a/lib/FusionInventory/Agent/Tools/Win32.pm
+++ b/lib/FusionInventory/Agent/Tools/Win32.pm
@@ -503,6 +503,10 @@ sub _call_win32_ole_dependent_api {
         return (exists($call->{'array'}) && $call->{'array'}) ?
             @{$result || []} : $result ;
     } else {
+        # Load Win32::OLE as late as possible
+        Win32::OLE->require() or return;
+        Win32::OLE->Option(CP => Win32::OLE::CP_UTF8());
+
         # We come here from worker or if we failed to start worker
         my $funct;
         eval {

--- a/lib/FusionInventory/Agent/Tools/Win32.pm
+++ b/lib/FusionInventory/Agent/Tools/Win32.pm
@@ -17,7 +17,6 @@ use constant KEY_WOW64_32 => 0x200;
 use Cwd;
 use Encode;
 use English qw(-no_match_vars);
-use Memoize;
 use File::Temp qw(:seekable tempfile);
 use Win32::Job;
 use Win32::TieRegistry (
@@ -29,7 +28,7 @@ use Win32::TieRegistry (
 use FusionInventory::Agent::Tools;
 use FusionInventory::Agent::Tools::Network;
 
-memoize('getLocalCodepage');
+my $localCodepage;
 
 our @EXPORT = qw(
     is64bit
@@ -54,10 +53,15 @@ sub is64bit {
 }
 
 sub getLocalCodepage {
-    return "cp" .
+    if (!$localCodepage) {
+        $localCodepage =
+            "cp" .
             getRegistryValue(
                 path => 'HKEY_LOCAL_MACHINE/SYSTEM/CurrentControlSet/Control/Nls/CodePage/ACP'
             );
+    }
+
+    return $localCodepage;
 }
 
 sub encodeFromRegistry {

--- a/t/01compile.t
+++ b/t/01compile.t
@@ -31,6 +31,8 @@ sub filter {
         return 0 if $_ =~ m{FusionInventory/Agent/Task/NetInventory.pm};
         return 0 if $_ =~ m{FusionInventory/Agent/Task/NetDiscovery.pm};
         return 0 if $_ =~ m{FusionInventory/Agent/Threads.pm};
+        return 0 if $_ =~ m{FusionInventory/Agent/Tools/Win32.pm};
+        return 0 if $_ =~ m{FusionInventory/Agent/Task/Inventory/Win32};
     }
 
     return 0 if ($_ =~ m{FusionInventory/Agent/Task/Deploy/P2P.pm} &&

--- a/t/tasks/deploy/p2p.t
+++ b/t/tasks/deploy/p2p.t
@@ -147,6 +147,11 @@ SKIP: {
     # Calling findPeers API requires Win32::OLE to be loaded to find interfaces
     # Later forked scanners must not crash the service while terminating
     if ($OSNAME eq 'MSWin32') {
+        # So from here we need to avoid crashes due to not thread-safe Win32::OLE
+        # Enabling a dedicated worker thread
+        FusionInventory::Agent::Tools::Win32->require();
+        FusionInventory::Agent::Tools::Win32::start_Win32_OLE_Worker();
+
         $p2p->findPeers();
     }
 

--- a/t/tasks/inventory/virtualization/hyperv.t
+++ b/t/tasks/inventory/virtualization/hyperv.t
@@ -10,7 +10,7 @@ use Test::Deep;
 use Test::Exception;
 use Test::MockModule;
 use Test::More;
-use Test::NoWarnings;
+use UNIVERSAL::require;
 
 use FusionInventory::Agent::Inventory;
 use FusionInventory::Test::Utils;
@@ -20,7 +20,15 @@ BEGIN {
     push @INC, 't/lib/fake/windows' if $OSNAME ne 'MSWin32';
 }
 
-use FusionInventory::Agent::Task::Inventory::Virtualization::HyperV;
+use Config;
+# check thread support availability
+if (!$Config{usethreads} || $Config{usethreads} ne 'define') {
+    plan skip_all => 'thread support required';
+}
+
+Test::NoWarnings->use();
+
+FusionInventory::Agent::Task::Inventory::Virtualization::HyperV->require();
 
 my %tests = (
     'unknown' => [

--- a/t/tasks/inventory/windows/bios.t
+++ b/t/tasks/inventory/windows/bios.t
@@ -8,7 +8,7 @@ use lib 't/lib';
 use English qw(-no_match_vars);
 use Test::More;
 use Test::MockModule;
-use Test::NoWarnings;
+use UNIVERSAL::require;
 
 use FusionInventory::Test::Utils;
 
@@ -17,7 +17,15 @@ BEGIN {
     push @INC, 't/lib/fake/windows' if $OSNAME ne 'MSWin32';
 }
 
-use FusionInventory::Agent::Task::Inventory::Win32::Bios;
+use Config;
+# check thread support availability
+if (!$Config{usethreads} || $Config{usethreads} ne 'define') {
+    plan skip_all => 'thread support required';
+}
+
+Test::NoWarnings->use();
+
+FusionInventory::Agent::Task::Inventory::Win32::Bios->require();
 
 my %tests = (
     "20050927******.******+***" => "09/27/2005",

--- a/t/tasks/inventory/windows/cpu.t
+++ b/t/tasks/inventory/windows/cpu.t
@@ -10,7 +10,6 @@ use Test::Deep;
 use Test::Exception;
 use Test::MockModule;
 use Test::More;
-use Test::NoWarnings;
 
 use FusionInventory::Agent::Inventory;
 use FusionInventory::Test::Utils;
@@ -20,7 +19,15 @@ BEGIN {
     push @INC, 't/lib/fake/windows' if $OSNAME ne 'MSWin32';
 }
 
-use FusionInventory::Agent::Task::Inventory::Win32::CPU;
+use Config;
+# check thread support availability
+if (!$Config{usethreads} || $Config{usethreads} ne 'define') {
+    plan skip_all => 'thread support required';
+}
+
+Test::NoWarnings->use();
+
+FusionInventory::Agent::Task::Inventory::Win32::CPU->require();
 
 my %tests = (
     '7' => [

--- a/t/tasks/inventory/windows/drives.t
+++ b/t/tasks/inventory/windows/drives.t
@@ -9,7 +9,6 @@ use Test::Deep;
 use Test::Exception;
 use Test::MockModule;
 use Test::More;
-use Test::NoWarnings;
 
 use FusionInventory::Agent::Inventory;
 use FusionInventory::Test::Utils;
@@ -19,7 +18,15 @@ BEGIN {
     push @INC, 't/lib/fake/windows' if $OSNAME ne 'MSWin32';
 }
 
-use FusionInventory::Agent::Task::Inventory::Win32::Drives;
+use Config;
+# check thread support availability
+if (!$Config{usethreads} || $Config{usethreads} ne 'define') {
+    plan skip_all => 'thread support required';
+}
+
+Test::NoWarnings->use();
+
+FusionInventory::Agent::Task::Inventory::Win32::Drives->require();
 
 my %tests = (
     'winxp-sp3-x86' => [

--- a/t/tasks/inventory/windows/license.t
+++ b/t/tasks/inventory/windows/license.t
@@ -7,7 +7,7 @@ use utf8;
 
 use English qw(-no_match_vars);
 use Test::More;
-use Test::NoWarnings;
+use UNIVERSAL::require;
 
 use FusionInventory::Test::Utils;
 
@@ -16,7 +16,15 @@ BEGIN {
     push @INC, 't/lib/fake/windows' if $OSNAME ne 'MSWin32';
 }
 
-use FusionInventory::Agent::Task::Inventory::Win32::License;
+use Config;
+# check thread support availability
+if (!$Config{usethreads} || $Config{usethreads} ne 'define') {
+    plan skip_all => 'thread support required';
+}
+
+Test::NoWarnings->use();
+
+FusionInventory::Agent::Task::Inventory::Win32::License->require();
 
 my %tests = (
     office_2010_1 => {

--- a/t/tasks/inventory/windows/memory.t
+++ b/t/tasks/inventory/windows/memory.t
@@ -10,7 +10,7 @@ use Test::Deep;
 use Test::Exception;
 use Test::MockModule;
 use Test::More;
-use Test::NoWarnings;
+use UNIVERSAL::require;
 
 use FusionInventory::Agent::Inventory;
 use FusionInventory::Test::Utils;
@@ -20,7 +20,15 @@ BEGIN {
     push @INC, 't/lib/fake/windows' if $OSNAME ne 'MSWin32';
 }
 
-use FusionInventory::Agent::Task::Inventory::Win32::Memory;
+use Config;
+# check thread support availability
+if (!$Config{usethreads} || $Config{usethreads} ne 'define') {
+    plan skip_all => 'thread support required';
+}
+
+Test::NoWarnings->use();
+
+FusionInventory::Agent::Task::Inventory::Win32::Memory->require();
 
 my %tests = (
     '7' => [

--- a/t/tasks/inventory/windows/networks.t
+++ b/t/tasks/inventory/windows/networks.t
@@ -7,7 +7,7 @@ use lib 't/lib';
 use English qw(-no_match_vars);
 use Test::More;
 use Test::MockModule;
-use Test::NoWarnings;
+use UNIVERSAL::require;
 
 use FusionInventory::Test::Utils;
 
@@ -16,7 +16,15 @@ BEGIN {
     push @INC, 't/lib/fake/windows' if $OSNAME ne 'MSWin32';
 }
 
-use FusionInventory::Agent::Task::Inventory::Win32::Networks;
+use Config;
+# check thread support availability
+if (!$Config{usethreads} || $Config{usethreads} ne 'define') {
+    plan skip_all => 'thread support required';
+}
+
+Test::NoWarnings->use();
+
+FusionInventory::Agent::Task::Inventory::Win32::Networks->require();
 
 my %tests = (
     xp => {

--- a/t/tasks/inventory/windows/printers.t
+++ b/t/tasks/inventory/windows/printers.t
@@ -7,7 +7,7 @@ use lib 't/lib';
 use English qw(-no_match_vars);
 use Test::More;
 use Test::MockModule;
-use Test::NoWarnings;
+use UNIVERSAL::require;
 
 use FusionInventory::Test::Utils;
 
@@ -16,7 +16,15 @@ BEGIN {
     push @INC, 't/lib/fake/windows' if $OSNAME ne 'MSWin32';
 }
 
-use FusionInventory::Agent::Task::Inventory::Win32::Printers;
+use Config;
+# check thread support availability
+if (!$Config{usethreads} || $Config{usethreads} ne 'define') {
+    plan skip_all => 'thread support required';
+}
+
+Test::NoWarnings->use();
+
+FusionInventory::Agent::Task::Inventory::Win32::Printers->require();
 
 my %tests = (
     xppro1 => {

--- a/t/tasks/inventory/windows/registry.t
+++ b/t/tasks/inventory/windows/registry.t
@@ -17,8 +17,13 @@ BEGIN {
     push @INC, 't/lib/fake/windows' if $OSNAME ne 'MSWin32';
 }
 
-use FusionInventory::Agent::Task::Inventory::Win32::Registry;
+use Config;
+# check thread support availability
+if (!$Config{usethreads} || $Config{usethreads} ne 'define') {
+    plan skip_all => 'thread support required';
+}
 
+FusionInventory::Agent::Task::Inventory::Win32::Registry->require();
 
 if ($OSNAME ne 'MSWin32') {
     plan skip_all => 'Windows-specific test';

--- a/t/tasks/inventory/windows/softwares.t
+++ b/t/tasks/inventory/windows/softwares.t
@@ -11,7 +11,7 @@ use Test::Deep;
 use Test::Exception;
 use Test::MockModule;
 use Test::More;
-use Test::NoWarnings;
+use UNIVERSAL::require;
 
 use FusionInventory::Agent::Inventory;
 use FusionInventory::Test::Utils;
@@ -21,8 +21,15 @@ BEGIN {
     push @INC, 't/lib/fake/windows' if $OSNAME ne 'MSWin32';
 }
 
+use Config;
+# check thread support availability
+if (!$Config{usethreads} || $Config{usethreads} ne 'define') {
+    plan skip_all => 'thread support required';
+}
 
-use FusionInventory::Agent::Task::Inventory::Win32::Softwares;
+Test::NoWarnings->use();
+
+FusionInventory::Agent::Task::Inventory::Win32::Softwares->require();
 
 my %softwares_tests = (
         xp => [

--- a/t/tasks/inventory/windows/storages.t
+++ b/t/tasks/inventory/windows/storages.t
@@ -9,7 +9,7 @@ use Test::Deep;
 use Test::Exception;
 use Test::MockModule;
 use Test::More;
-use Test::NoWarnings;
+use UNIVERSAL::require;
 
 use FusionInventory::Agent::Inventory;
 use FusionInventory::Test::Utils;
@@ -19,7 +19,15 @@ BEGIN {
     push @INC, 't/lib/fake/windows' if $OSNAME ne 'MSWin32';
 }
 
-use FusionInventory::Agent::Task::Inventory::Win32::Storages;
+use Config;
+# check thread support availability
+if (!$Config{usethreads} || $Config{usethreads} ne 'define') {
+    plan skip_all => 'thread support required';
+}
+
+Test::NoWarnings->use();
+
+FusionInventory::Agent::Task::Inventory::Win32::Storages->require();
 
 my %tests = (
     'win7-sp1-x64' => [

--- a/t/tasks/inventory/windows/usb.t
+++ b/t/tasks/inventory/windows/usb.t
@@ -10,7 +10,7 @@ use Test::Deep;
 use Test::Exception;
 use Test::MockModule;
 use Test::More;
-use Test::NoWarnings;
+use UNIVERSAL::require;
 
 use FusionInventory::Agent::Inventory;
 use FusionInventory::Test::Utils;
@@ -20,7 +20,15 @@ BEGIN {
     push @INC, 't/lib/fake/windows' if $OSNAME ne 'MSWin32';
 }
 
-use FusionInventory::Agent::Task::Inventory::Win32::USB;
+use Config;
+# check thread support availability
+if (!$Config{usethreads} || $Config{usethreads} ne 'define') {
+    plan skip_all => 'thread support required';
+}
+
+Test::NoWarnings->use();
+
+FusionInventory::Agent::Task::Inventory::Win32::USB->require();
 
 my %tests = (
     7 => [


### PR DESCRIPTION
Use Perl threads to handle a dedicated worker thread. This thread only job is just to handle few calls from FusionInventory::Agent::Tools::Win32 that are known to crash perl under win32. This calls are using Win32:OLE module and and as this last depends on not thread-safe system DLL, they can trigger crash while forked tasks are exiting.