### PR TITLE
bug : McAfee antivirus data on Win32

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/Win32/AntiVirus.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Win32/AntiVirus.pm
@@ -143,9 +143,9 @@ sub _addMcAfeeData {
 }
 
 sub _formatMcAfeeVersion {
-    my ($str1, $str2) = shift;
+    my ($str1, $str2) = @_;
 
-    my $str = sprintf("%04h.%04h", $str1, $str2);
+    my $str = sprintf("%04d.%04d", hex($str1), hex($str2));
 
     return $str;
 }

--- a/lib/FusionInventory/Agent/Task/Inventory/Win32/AntiVirus.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Win32/AntiVirus.pm
@@ -94,7 +94,7 @@ sub _getMcAfeeInfo {
         my $keys = $properties{$property};
         my $major = getRegistryValue(path => $path . '/' . $keys->[0]);
         my $minor = getRegistryValue(path => $path . '/' . $keys->[1]);
-        $info->{$property} = sprintf("%04h.%04h", $major, $minor)
+        $info->{$property} = sprintf("%04d.%04d", hex($major), hex($minor))
             if defined $major && defined $major;
     }
 


### PR DESCRIPTION
1) sprintf does not convert anything, it simply prints... so use of hex function is required 
There as a failure when converting version numbers. They are hex values so they have to be converted with hex function and then printed as integers with sprintf
We have hex values like '0x000016a8' and we want to convert it to integers
2) use of @_ instead of shift to get the function parameters...