### PR TITLE
Bug : after config reload, wrong display of planned tasks

### DIFF
--- a/etc/agent.cfg
+++ b/etc/agent.cfg
@@ -21,7 +21,7 @@
 
 # disable software deployment tasks
 #no-task = deploy
-#tasks = inventory, deploy, inventory,...
+#tasks = inventory,deploy,inventory
 
 #
 # Target scheduling options

--- a/lib/FusionInventory/Agent.pm
+++ b/lib/FusionInventory/Agent.pm
@@ -204,8 +204,8 @@ sub reinit {
     }
     $logger->debug("Planned tasks:");
     foreach my $task (@{$self->{tasksExecutionPlan}}) {
-        $task = lc $task;
-        $logger->debug("- $task: " . $available{$available_lc{$task}});
+        my $task_lc = lc $task;
+        $logger->debug("- $task: " . $available{$available_lc{$task_lc}});
     }
 
     $self->{tasks} = \@tasks;


### PR DESCRIPTION
1) Due to case insensitive option ('tasks' option), the real case of task names was lost
2) For the tasks option, when using the example provided in file 'etc/agent.cfg' (just uncommenting the line), the option did not work : the values must be written separated by a comma and no space character. 