### PR TITLE
Forced minimum for 'conf-reload-interval' option

### DIFF
--- a/bin/fusioninventory-agent
+++ b/bin/fusioninventory-agent
@@ -313,8 +313,6 @@ Do not run given task.
 Multiple values can be specified, using comma as a separator. See option
 I<--list-tasks> for the list of available tasks.
 
-=back
-
 =item B<--tasks>=I<TASK>
 
 Run given tasks in given order.
@@ -586,12 +584,12 @@ none: don't read any configuration.
 
 Use I<FILE> as configuration file (implies file configuration backend).
 
-=back
-
 =item B<--conf-reload-interval>=I<SECONDS>
 
 SECONDS is the number of seconds between two configuration reloadings.
 Default value is 0, which means that configuration is never reloaded.
+Minimum value is 60. If given value is less than this minimum, it is set to
+this minimum. If given value is less than 0, it is set to 0.
 
 =back
 

--- a/lib/FusionInventory/Agent/Config.pm
+++ b/lib/FusionInventory/Agent/Config.pm
@@ -56,6 +56,8 @@ my $deprecated = {
     },
 };
 
+my $confReloadIntervalMinValue = 60;
+
 sub new {
     my ($class, %params) = @_;
 
@@ -294,6 +296,18 @@ sub _checkContent {
         File::Spec->rel2abs($self->{'ca-cert-dir'}) if $self->{'ca-cert-dir'};
     $self->{'logfile'} =
         File::Spec->rel2abs($self->{'logfile'}) if $self->{'logfile'};
+
+    # conf-reload-interval option
+    # If value is less than the required minimum, we force it to that
+    # minimum because it's useless to reload the config so often and,
+    # furthermore, it can cause a loss of performance
+    if ($self->{'conf-reload-interval'} != 0) {
+        if ($self->{'conf-reload-interval'} < 0) {
+            $self->{'conf-reload-interval'} = 0;
+        } elsif ($self->{'conf-reload-interval'} < $confReloadIntervalMinValue) {
+            $self->{'conf-reload-interval'} = $confReloadIntervalMinValue;
+        }
+    }
 }
 
 sub isParamArrayAndFilled {

--- a/resources/config/sample2
+++ b/resources/config/sample2
@@ -2,3 +2,4 @@
 #no-software=1
 no-category=printer
 httpd-trust=example,127.0.0.1,foobar,123.0.0.0/10
+conf-reload-interval=-5

--- a/resources/config/sample3
+++ b/resources/config/sample3
@@ -1,1 +1,2 @@
 # no-inventory=1
+conf-reload-interval=3600

--- a/resources/config/sample4
+++ b/resources/config/sample4
@@ -2,3 +2,4 @@
 no-task=snmpquery,wakeonlan,inventory
 #no-software=1
 tasks=inventory, deploy , inventory
+conf-reload-interval=15

--- a/t/agent/config.t
+++ b/t/agent/config.t
@@ -18,34 +18,38 @@ my %config = (
         'no-task'     => ['snmpquery', 'wakeonlan'],
         'no-category' => [],
         'httpd-trust' => [],
-        'tasks'       => ['inventory', 'deploy', 'inventory']
+        'tasks'       => ['inventory', 'deploy', 'inventory'],
+        'conf-reload-interval' => 0
     },
     sample2 => {
         'no-task'     => [],
         'no-category' => ['printer'],
-        'httpd-trust' => ['example', '127.0.0.1', 'foobar', '123.0.0.0/10']
+        'httpd-trust' => ['example', '127.0.0.1', 'foobar', '123.0.0.0/10'],
+        'conf-reload-interval' => 0
     },
     sample3 => {
         'no-task'     => [],
         'no-category' => [],
-        'httpd-trust' => []
+        'httpd-trust' => [],
+        'conf-reload-interval' => 3600
     },
     sample4 => {
         'no-task'     => ['snmpquery','wakeonlan','inventory'],
         'no-category' => [],
         'httpd-trust' => [],
-        'tasks'       => ['inventory', 'deploy', 'inventory']
+        'tasks'       => ['inventory', 'deploy', 'inventory'],
+        'conf-reload-interval' => 60
     }
 );
 
-plan tests => (scalar keys %config) * 3 + 16 + 18;
+plan tests => (scalar keys %config) * 4 + 16 + 18;
 
 foreach my $test (keys %config) {
     my $c = FusionInventory::Agent::Config->new(options => {
         'conf-file' => "resources/config/$test"
     });
 
-    foreach my $k (qw/ no-task no-category httpd-trust /) {
+    foreach my $k (qw/ no-task no-category httpd-trust conf-reload-interval /) {
         cmp_deeply($c->{$k}, $config{$test}->{$k}, $test." ".$k);
     }
 


### PR DESCRIPTION
As suggested, we introduce a minimum for 'conf-reload-interval' option. For now, this minimum is set to 60 (in seconds)