### PR TITLE
Do not verify SSL mode while connecting to VMware server

### DIFF
--- a/lib/FusionInventory/Agent/SOAP/VMware.pm
+++ b/lib/FusionInventory/Agent/SOAP/VMware.pm
@@ -25,7 +25,7 @@ sub new {
         requests_redirectable => ['POST', 'GET', 'HEAD'],
         agent                 => $FusionInventory::Agent::AGENT_STRING,
         timeout               => $params{timeout} || 180,
-        ssl_opts              => { verify_hostname => 0 },
+        ssl_opts              => { verify_hostname => 0, SSL_verify_mode => 0 },
         cookie_jar            => HTTP::Cookies->new(ignore_discard => 1),
     );
 


### PR DESCRIPTION
Fix `500 Can't connect to X.X.X.X:443 (certificate verify failed)` error messages on ESX task requests. 