### PR TITLE
getting TAG during PROLOG

### DIFF
--- a/lib/FusionInventory/Agent.pm
+++ b/lib/FusionInventory/Agent.pm
@@ -340,6 +340,9 @@ sub _runTarget {
         if (defined($content->{PROLOG_FREQ})) {
             $target->setMaxDelay($content->{PROLOG_FREQ} * 3600);
         }
+        if (defined($content->{PROLOG_TAG}) && $content->{PROLOG_TAG} !~ /^\s*$/) {
+            $self->{config}->{tag} = $content->{PROLOG_TAG};
+        }
     }
 
     foreach my $name (@{$self->{tasksExecutionPlan}}) {
@@ -396,6 +399,7 @@ sub _runTaskReal {
 
     $class->require();
 
+    $self->{logger}->debug2('creating object of type ' . $class . ' with tag ' . $self->{config}->{tag});
     my $task = $class->new(
         config       => $self->{config},
         confdir      => $self->{confdir},


### PR DESCRIPTION
If 'PROLOG_TAG' is in content provided by prolog request and is not empty string, we load it in the agent's config as the value of 'tag' key