### PR TITLE
recognize Solaris 11 and later and use its own packaging tool

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/Solaris/Softwares.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Solaris/Softwares.pm
@@ -4,13 +4,21 @@ use strict;
 use warnings;
 
 use FusionInventory::Agent::Tools;
+use FusionInventory::Agent::Tools::Solaris;
 
 sub isEnabled {
     my (%params) = @_;
 
-    return
-        !$params{no_category}->{software} &&
-        canRun('pkginfo');
+    my $info = getReleaseInfo();
+    if ($info->{version} > 10) {
+    	return
+    	    !$params{no_category}->{software} &&
+    	    canRun('pkg');
+    } else {
+    	return
+    	    !$params{no_category}->{software} &&
+    	    canRun('pkginfo');
+    }
 }
 
 sub doInventory {
@@ -19,30 +27,59 @@ sub doInventory {
     my $inventory = $params{inventory};
     my $logger    = $params{logger};
 
-    my $handle = getFileHandle(
-        command => 'pkginfo -l',
-        logger  => $logger,
-    );
+    my $handle;
+    my $info = getReleaseInfo();
+    if ($info->{version} > 10) {
+    	$handle = getFileHandle(
+    	    command => 'pkg info',
+    	    logger  => $logger,
+    	);
+    } else {
+    	$handle = getFileHandle(
+    	    command => 'pkginfo -l',
+    	    logger  => $logger,
+    	);
+    }
 
     return unless $handle;
 
     my $software;
-    while (my $line = <$handle>) {
-        if ($line =~ /^\s*$/) {
-            $inventory->addEntry(
-                section => 'SOFTWARES',
-                entry   =>  $software
-            );
-            undef $software;
-        } elsif ($line =~ /PKGINST:\s+(.+)/) {
-            $software->{NAME} = $1;
-        } elsif ($line =~ /VERSION:\s+(.+)/) {
-            $software->{VERSION} = $1;
-        } elsif ($line =~ /VENDOR:\s+(.+)/) {
-            $software->{PUBLISHER} = $1;
-        } elsif ($line =~  /DESC:\s+(.+)/) {
-            $software->{COMMENTS} = $1;
-        }
+    if ($info->{version} > 10) {
+    	while (my $line = <$handle>) {
+    	    if ($line =~ /^\s*$/) {
+        		$inventory->addEntry(
+        		    section => 'SOFTWARES',
+        		    entry   =>  $software
+        		);
+    		    undef $software;
+    	    } elsif ($line =~ /Name:\s+(.+)/) {
+    		    $software->{NAME} = $1;
+    	    } elsif ($line =~ /FMRI:\s+.+\@(.+)/) {
+    		    $software->{VERSION} = $1;
+    	    } elsif ($line =~ /Publisher:\s+(.+)/) {
+    		    $software->{PUBLISHER} = $1;
+    	    } elsif ($line =~  /Summary:\s+(.+)/) {
+    		    $software->{COMMENTS} = $1;
+    	    }
+    	}
+    } else {
+    	while (my $line = <$handle>) {
+    	    if ($line =~ /^\s*$/) {
+        		$inventory->addEntry(
+        		    section => 'SOFTWARES',
+        		    entry   =>  $software
+        		);
+        		undef $software;
+    	    } elsif ($line =~ /PKGINST:\s+(.+)/) {
+        		$software->{NAME} = $1;
+    	    } elsif ($line =~ /VERSION:\s+(.+)/) {
+        		$software->{VERSION} = $1;
+    	    } elsif ($line =~ /VENDOR:\s+(.+)/) {
+        		$software->{PUBLISHER} = $1;
+    	    } elsif ($line =~  /DESC:\s+(.+)/) {
+        		$software->{COMMENTS} = $1;
+    	    }
+    	}
     }
 
     close $handle;

--- a/lib/FusionInventory/Agent/Task/Inventory/Solaris/Softwares.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Solaris/Softwares.pm
@@ -19,65 +19,69 @@ sub doInventory {
     my $inventory = $params{inventory};
     my $logger    = $params{logger};
 
-    my $handle;
-    
-    my $usepkg = 0;
-    $usepkg = 1 if (canRun('pkg'));
-    
-    if ($usepkg) {
-    	$handle = getFileHandle(
-    	    command => 'pkg info',
-    	    logger  => $logger,
-    	);
-    } else {
-    	$handle = getFileHandle(
-    	    command => 'pkginfo -l',
-    	    logger  => $logger,
-    	);
+    my $pkgs = _parse_pkgs(logger => $logger);
+    return unless $pkgs;
+
+    foreach my $pkg (@$pkgs) {
+        $inventory->addEntry(
+            section => 'SOFTWARES',
+            entry   =>  $pkg
+        );
+    }
+}
+
+sub _parse_pkgs {
+    my (%params) = @_;
+
+    if (!defined $params{command}) {
+        if (canRun('pkg')) {
+            $params{command} = 'pkg info';
+        } else {
+            $params{command} = 'pkginfo -l';
+        }
     }
 
+    my $handle = getFileHandle(%params);
     return unless $handle;
 
+    my @softwares;
     my $software;
-    if ($usepkg) {
-    	while (my $line = <$handle>) {
-    	    if ($line =~ /^\s*$/) {
-        		$inventory->addEntry(
-        		    section => 'SOFTWARES',
-        		    entry   =>  $software
-        		);
-    		    undef $software;
-    	    } elsif ($line =~ /Name:\s+(.+)/) {
-    		    $software->{NAME} = $1;
-    	    } elsif ($line =~ /FMRI:\s+.+\@(.+)/) {
-    		    $software->{VERSION} = $1;
-    	    } elsif ($line =~ /Publisher:\s+(.+)/) {
-    		    $software->{PUBLISHER} = $1;
-    	    } elsif ($line =~  /Summary:\s+(.+)/) {
-    		    $software->{COMMENTS} = $1;
-    	    }
-    	}
+    if ($params{command} =~ /pkg info/) {
+        while (my $line = <$handle>) {
+            if ($line =~ /^\s*$/) {
+                push @softwares, $software if $software;
+                undef $software;
+            } elsif ($line =~ /Name:\s+(.+)/) {
+                $software->{NAME} = $1;
+            } elsif ($line =~ /FMRI:\s+.+\@(.+)/) {
+                $software->{VERSION} = $1;
+            } elsif ($line =~ /Publisher:\s+(.+)/) {
+                $software->{PUBLISHER} = $1;
+            } elsif ($line =~  /Summary:\s+(.+)/) {
+                $software->{COMMENTS} = $1;
+            }
+        }
     } else {
-    	while (my $line = <$handle>) {
-    	    if ($line =~ /^\s*$/) {
-        		$inventory->addEntry(
-        		    section => 'SOFTWARES',
-        		    entry   =>  $software
-        		);
-        		undef $software;
-    	    } elsif ($line =~ /PKGINST:\s+(.+)/) {
-        		$software->{NAME} = $1;
-    	    } elsif ($line =~ /VERSION:\s+(.+)/) {
-        		$software->{VERSION} = $1;
-    	    } elsif ($line =~ /VENDOR:\s+(.+)/) {
-        		$software->{PUBLISHER} = $1;
-    	    } elsif ($line =~  /DESC:\s+(.+)/) {
-        		$software->{COMMENTS} = $1;
-    	    }
-    	}
+        while (my $line = <$handle>) {
+            if ($line =~ /^\s*$/) {
+                push @softwares, $software if $software;
+                undef $software;
+            } elsif ($line =~ /PKGINST:\s+(.+)/) {
+                $software->{NAME} = $1;
+            } elsif ($line =~ /VERSION:\s+(.+)/) {
+                $software->{VERSION} = $1;
+            } elsif ($line =~ /VENDOR:\s+(.+)/) {
+                $software->{PUBLISHER} = $1;
+            } elsif ($line =~  /DESC:\s+(.+)/) {
+                $software->{COMMENTS} = $1;
+            }
+        }
     }
 
+    push @softwares, $software if $software;
+
     close $handle;
+    return \@softwares;
 }
 
 1;

--- a/resources/solaris/pkg-info/sample
+++ b/resources/solaris/pkg-info/sample
@@ -1,0 +1,57 @@
+          Name: archiver/gnu-tar
+       Summary: GNU version of the tar archiving utility
+   Description: Tar is a program for packaging a set of files as a single
+                archive in tar format.
+      Category: Development/GNU
+         State: Installed
+     Publisher: solaris
+       Version: 1.26
+ Build Release: 5.11
+        Branch: 0.175.1.0.0.24.0
+Packaging Date: September  4, 2012 05:05:45 PM 
+          Size: 1.63 MB
+          FMRI: pkg://solaris/archiver/gnu-tar@1.26,5.11-0.175.1.0.0.24.0:20120904T170545Z
+
+          Name: audio/audio-utilities
+       Summary: Audio Applications
+   Description: Audio applications including audioconvert(1), audioplay(1),
+                audiorecord(1) and audiotest(1)
+      Category: System/Media
+         State: Installed
+     Publisher: solaris
+       Version: 0.5.11
+ Build Release: 5.11
+        Branch: 0.175.1.0.0.24.2
+Packaging Date: September 19, 2012 06:41:17 PM 
+          Size: 830.83 kB
+          FMRI: pkg://solaris/audio/audio-utilities@0.5.11,5.11-0.175.1.0.0.24.2:20120919T184117Z
+
+          Name: benchmark/iperf
+       Summary: iperf - tool for measuring maximum TCP and UDP bandwidth performance
+      Category: Applications/System Utilities
+         State: Installed
+     Publisher: solaris
+       Version: 2.0.4
+ Build Release: 5.11
+        Branch: 0.175.1.0.0.24.0
+Packaging Date: September  4, 2012 05:06:01 PM 
+          Size: 131.81 kB
+          FMRI: pkg://solaris/benchmark/iperf@2.0.4,5.11-0.175.1.0.0.24.0:20120904T170601Z
+
+          Name: entire
+       Summary: entire incorporation including Support Repository Update (Oracle Solaris 11.1 SRU 4.5).
+   Description: This package constrains system package versions to the same
+                build.  WARNING: Proper system update and correct package
+                selection depend on the presence of this incorporation.
+                Removing this package will result in an unsupported system.  For
+                more information see https://support.oracle.com/CSP/main/article
+                ?cmd=show&type=NOT&doctype=REFERENCE&id=1501435.1.
+      Category: Meta Packages/Incorporations
+         State: Installed
+     Publisher: solaris
+       Version: 0.5.11 (Oracle Solaris 11.1 SRU 4.5)
+ Build Release: 5.11
+        Branch: 0.175.1.4.0.5.0
+Packaging Date: February 12, 2013 04:17:54 PM 
+          Size: 5.46 kB
+          FMRI: pkg://solaris/entire@0.5.11,5.11-0.175.1.4.0.5.0:20130212T161754Z

--- a/resources/solaris/pkg-info/sample-sol10
+++ b/resources/solaris/pkg-info/sample-sol10
@@ -1,0 +1,54 @@
+   PKGINST:  SUNWgtar
+      NAME:  gtar - GNU tar
+  CATEGORY:  system
+      ARCH:  i386
+   VERSION:  11.10.0,REV=2005.01.08.01.09
+   BASEDIR:  /
+    VENDOR:  Oracle Corporation
+      DESC:  GNU tar - A utility used to store, backup, and transport files (gtar) 1.25
+    PSTAMP:  sfw10-patch-x20110415095946
+  INSTDATE:  Jul 31 2013 22:23
+   HOTLINE:  Please contact your local service provider
+    STATUS:  completely installed
+     FILES:        6 installed pathnames
+                   4 shared pathnames
+                   4 directories
+                   2 executables
+                 711 blocks used (approx)
+
+   PKGINST:  SUNWauda
+      NAME:  Audio Applications
+  CATEGORY:  system
+      ARCH:  i386
+   VERSION:  11.10.0,REV=2005.01.21.16.34
+   BASEDIR:  /
+    VENDOR:  Oracle Corporation
+      DESC:  SunOS audio applications
+    PSTAMP:  on10ptchfeatx20110619221650
+  INSTDATE:  Jul 31 2013 22:26
+   HOTLINE:  Please contact your local service provider
+    STATUS:  completely installed
+     FILES:        7 installed pathnames
+                   3 shared pathnames
+                   3 directories
+                   4 executables
+                 669 blocks used (approx)
+
+   PKGINST:  SUNWbip
+      NAME:  Basic IP commands (Usr)
+  CATEGORY:  system
+      ARCH:  i386
+   VERSION:  11.10.0,REV=2005.01.21.16.34
+   BASEDIR:  /
+    VENDOR:  Oracle Corporation
+      DESC:  Basic IP commands (/usr/sbin/ping, /bin/ftp)
+    PSTAMP:  on10ptchfeatx20110619221738
+  INSTDATE:  Jul 31 2013 22:17
+   HOTLINE:  Please contact your local service provider
+    STATUS:  completely installed
+     FILES:        5 installed pathnames
+                   3 shared pathnames
+                   3 directories
+                   2 executables
+                   1 setuid/setgid executables
+                 259 blocks used (approx)

--- a/t/tasks/inventory/solaris/softwares.t
+++ b/t/tasks/inventory/solaris/softwares.t
@@ -1,0 +1,89 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use lib 't/lib';
+
+use Test::Deep;
+use Test::Exception;
+use Test::More;
+use Test::NoWarnings;
+
+use FusionInventory::Test::Inventory;
+use FusionInventory::Agent::Task::Inventory::Solaris::Softwares;
+
+my %pkg_tests = (
+    'sample' => [
+        {  
+            COMMENTS   => 'GNU version of the tar archiving utility',
+            NAME       => 'archiver/gnu-tar',
+            PUBLISHER  => 'solaris',
+            VERSION    => '1.26,5.11-0.175.1.0.0.24.0:20120904T170545Z',
+        },
+        {  
+            COMMENTS   => 'Audio Applications',
+            NAME       => 'audio/audio-utilities',
+            PUBLISHER  => 'solaris',
+            VERSION    => '0.5.11,5.11-0.175.1.0.0.24.2:20120919T184117Z',
+        },
+        {  
+            COMMENTS   => 'iperf - tool for measuring maximum TCP and UDP bandwidth performance',
+            NAME       => 'benchmark/iperf',
+            PUBLISHER  => 'solaris',
+            VERSION    => '2.0.4,5.11-0.175.1.0.0.24.0:20120904T170601Z',
+        },
+        {  
+            COMMENTS   => 'entire incorporation including Support Repository Update (Oracle Solaris 11.1 SRU 4.5).',
+            NAME       => 'entire',
+            PUBLISHER  => 'solaris',
+            VERSION    => '0.5.11,5.11-0.175.1.4.0.5.0:20130212T161754Z',
+        }
+    ]
+);
+my %pkginfo_tests = (
+    'sample-sol10' => [
+        {  
+            COMMENTS   => 'GNU tar - A utility used to store, backup, and transport files (gtar) 1.25',
+            NAME       => 'SUNWgtar',
+            PUBLISHER  => 'Oracle Corporation',
+            VERSION    => '11.10.0,REV=2005.01.08.01.09',
+        },
+        {  
+            COMMENTS   => 'SunOS audio applications',
+            NAME       => 'SUNWauda',
+            PUBLISHER  => 'Oracle Corporation',
+            VERSION    => '11.10.0,REV=2005.01.21.16.34',
+        },
+        {  
+            COMMENTS   => 'Basic IP commands (/usr/sbin/ping, /bin/ftp)',
+            NAME       => 'SUNWbip',
+            PUBLISHER  => 'Oracle Corporation',
+            VERSION    => '11.10.0,REV=2005.01.21.16.34',
+        }
+    ]
+
+);
+
+plan tests => 2 * (scalar keys %pkg_tests) + 2 * (scalar keys %pkginfo_tests) + 1;
+
+my $inventory = FusionInventory::Test::Inventory->new();
+
+foreach my $test (keys %pkg_tests) {
+    my $file = "resources/solaris/pkg-info/$test";
+    my $softwares = FusionInventory::Agent::Task::Inventory::Solaris::Softwares::_parse_pkgs(file => $file, command => 'pkg info');
+    cmp_deeply($softwares, $pkg_tests{$test}, "$test: parsing");
+    lives_ok {
+        $inventory->addEntry(section => 'SOFTWARES', entry => $_)
+            foreach @$softwares;
+    } "$test: registering";
+}
+
+foreach my $test (keys %pkginfo_tests) {
+    my $file = "resources/solaris/pkg-info/$test";
+    my $softwares = FusionInventory::Agent::Task::Inventory::Solaris::Softwares::_parse_pkgs(file => $file, command => 'pkginfo -l');
+    cmp_deeply($softwares, $pkginfo_tests{$test}, "$test: parsing");
+    lives_ok {
+        $inventory->addEntry(section => 'SOFTWARES', entry => $_)
+            foreach @$softwares;
+    } "$test: registering";
+}


### PR DESCRIPTION
Solaris 11 and later use "pkg".
The earlier "pkginfo" is still present in Solaris 11, but does not provide all the information "pkg" does, like e.g. the overall patch level of the OS.