### PR TITLE
2.3.x Win32 : Bug when starting agent from sources

### DIFF
--- a/bin/fusioninventory-win32-service
+++ b/bin/fusioninventory-win32-service
@@ -57,7 +57,7 @@ if ($options->{register}) {
         name    => $options->{name}        || SERVICE_NAME,
         display => $options->{displayname} || SERVICE_DISPLAYNAME,
         path    => "$^X",
-        parameters => "-I$libdir ".File::Spec->rel2abs( __FILE__ )
+        parameters => '-I"' . $libdir . '" "' . File::Spec->rel2abs( __FILE__ ) . '"'
     };
 
     if (!Win32::Daemon::CreateService($service)) {


### PR DESCRIPTION
Parameters in command line must be quoted... if not,, the service's startup  will silently crash if one of the parameters contains a space character (Documents ans settings  windows folder for instance)