### PR TITLE
2.3.x bug mac os104 boottime

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/MacOS.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/MacOS.pm
@@ -37,6 +37,12 @@ sub doInventory {
         command => "sysctl -n kern.boottime",
         pattern => qr/sec = (\d+)/
     );
+    if (!$boottime) {
+        $boottime = getFirstMatch(
+            command => "sysctl -n kern.boottime",
+            pattern => qr/sec = (\d+)/
+        );
+    }
 
     $inventory->setHardware({
         OSNAME     => $name,

--- a/lib/FusionInventory/Agent/Task/Inventory/MacOS.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/MacOS.pm
@@ -38,9 +38,8 @@ sub doInventory {
         pattern => qr/sec = (\d+)/
     );
     if (!$boottime) {
-        $boottime = getFirstMatch(
-            command => "sysctl -n kern.boottime",
-            pattern => qr/sec = (\d+)/
+        $boottime = getFirstLine(
+            command => "sysctl -n kern.boottime"
         );
     }
 


### PR DESCRIPTION
boottime not retrieved on Mac Os 10.4. Now fixed