### PR TITLE
2.3.x+hyper v fix

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/Virtualization/HyperV.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Virtualization/HyperV.pm
@@ -36,7 +36,8 @@ sub _getVirtualMachines {
     # index memory, cpu and BIOS UUID information
     my %memory;
     foreach my $object (FusionInventory::Agent::Tools::Win32::getWMIObjects(
-        moniker    => 'winmgmts://./root/virtualization',
+        moniker    => 'winmgmts://./root/virtualization/v2',
+        altmoniker => 'winmgmts://./root/virtualization',
         class      => 'MSVM_MemorySettingData',
         properties => [ qw/InstanceID VirtualQuantity/ ]
     )) {
@@ -47,7 +48,8 @@ sub _getVirtualMachines {
 
     my %vcpu;
     foreach my $object (FusionInventory::Agent::Tools::Win32::getWMIObjects(
-        moniker    => 'winmgmts://./root/virtualization',
+        moniker    => 'winmgmts://./root/virtualization/v2',
+        altmoniker => 'winmgmts://./root/virtualization',
         class      => 'MSVM_ProcessorSettingData',
         properties => [ qw/InstanceID VirtualQuantity/ ]
     )) {
@@ -58,8 +60,9 @@ sub _getVirtualMachines {
 
     my %biosguid;
     foreach my $object (FusionInventory::Agent::Tools::Win32::getWMIObjects(
-        moniker => 'winmgmts://./root/virtualization',
-        class => 'MSVM_VirtualSystemSettingData',
+        moniker    => 'winmgmts://./root/virtualization/v2',
+        altmoniker => 'winmgmts://./root/virtualization',
+        class      => 'MSVM_VirtualSystemSettingData',
         properties => [ qw/InstanceID BIOSGUID/ ]
     )) {
         my $id = $object->{InstanceID};
@@ -69,7 +72,8 @@ sub _getVirtualMachines {
     }
 
     foreach my $object (FusionInventory::Agent::Tools::Win32::getWMIObjects(
-        moniker    => 'winmgmts://./root/virtualization',
+        moniker    => 'winmgmts://./root/virtualization/v2',
+        altmoniker => 'winmgmts://./root/virtualization',
         class      => 'MSVM_ComputerSystem',
         properties => [ qw/ElementName EnabledState Name/ ]
     )) {

--- a/lib/FusionInventory/Agent/Tools/Win32.pm
+++ b/lib/FusionInventory/Agent/Tools/Win32.pm
@@ -91,8 +91,15 @@ sub _getWMIObjects {
         @_
     );
 
-    my $WMIService = Win32::OLE->GetObject($params{moniker})
-        or return;
+    my $WMIService = Win32::OLE->GetObject($params{moniker});
+
+    # Support alternate moniker if provided and main failed to open
+    unless (defined($WMIService)) {
+        if ($params{altmoniker}) {
+            $WMIService = Win32::OLE->GetObject($params{altmoniker});
+        }
+        return unless (defined($WMIService));
+    }
 
     Win32::OLE->use('in');
 
@@ -554,6 +561,8 @@ Returns the list of objects from given WMI class, with given properties, properl
 =over
 
 =item moniker a WMI moniker (default: winmgmts:{impersonationLevel=impersonate,(security)}!//./)
+
+=item altmoniker another WMI moniker to use if first failed (none by default)
 
 =item class a WMI class
 


### PR DESCRIPTION
* Add support for alternate moniker in getWMIObjects() API
* Try to use alternate moniker as fallback if new Hyper-V WMI namespace is not found

This should fix [forge bug 2872](http://forge.fusioninventory.org/issues/2872)

[Tests passed on Appveyor](https://ci.appveyor.com/project/g-bougard/fusioninventory-agent/build/2.3.x+hyperV-fix-119)