### PR TITLE
Mac OS X boottime refactoring

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/MacOS.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/MacOS.pm
@@ -33,15 +33,7 @@ sub doInventory {
         $name = "Mac OS X";
     }
 
-    my $boottime = getFirstMatch(
-        command => "sysctl -n kern.boottime",
-        pattern => qr/sec = (\d+)/
-    );
-    if (!$boottime) {
-        $boottime = getFirstLine(
-            command => "sysctl -n kern.boottime"
-        );
-    }
+    my $boottime = getBootTime();
 
     $inventory->setHardware({
         OSNAME     => $name,

--- a/lib/FusionInventory/Agent/Task/Inventory/MacOS/Uptime.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/MacOS/Uptime.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use FusionInventory::Agent::Tools;
+use FusionInventory::Agent::Tools::MacOS;
 
 sub isEnabled {
     return getFirstLine(command => 'sysctl -n kern.boottime');
@@ -22,12 +23,7 @@ sub doInventory {
 }
 
 sub _getBootTime {
-    my $boottime = getFirstMatch(
-        pattern => qr/(\d+)$/,
-        @_,
-    );
-
-    return $boottime;
+    return FusionInventory::Agent::Tools::MacOS::getBootTime(@_);
 }
 
 sub _getUptime {

--- a/lib/FusionInventory/Agent/Task/Inventory/MacOS/Uptime.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/MacOS/Uptime.pm
@@ -22,12 +22,8 @@ sub doInventory {
     });
 }
 
-sub _getBootTime {
-    return FusionInventory::Agent::Tools::MacOS::getBootTime(@_);
-}
-
 sub _getUptime {
-    my $boottime = _getBootTime(@_);
+    my $boottime = return FusionInventory::Agent::Tools::MacOS::getBootTime(@_);
     return unless $boottime;
 
     my $uptime = time() - $boottime;

--- a/lib/FusionInventory/Agent/Tools/MacOS.pm
+++ b/lib/FusionInventory/Agent/Tools/MacOS.pm
@@ -14,6 +14,7 @@ use FusionInventory::Agent::Tools;
 our @EXPORT = qw(
     getSystemProfilerInfos
     getIODevices
+    getBootTime
 );
 
 memoize('getSystemProfilerInfos');
@@ -411,6 +412,20 @@ sub getIODevices {
     close $handle;
 
     return @devices;
+}
+
+sub getBootTime {
+    my (%params) = @_;
+    if (!$params{string} && !$params{command}) {
+        $params{command} = 'sysctl -n kern.boottime';
+    }
+
+    my $boottime = getFirstMatch(
+        pattern => qr/(\d+)$/,
+        %params
+    );
+
+    return $boottime;
 }
 
 1;

--- a/t/agent/tools/macos.t
+++ b/t/agent/tools/macos.t
@@ -5,6 +5,7 @@ use warnings;
 
 use Test::Deep;
 use Test::More;
+use English;
 
 use FusionInventory::Agent::Tools::MacOS;
 use FusionInventory::Agent::Task::Inventory::MacOS::Softwares;
@@ -3384,7 +3385,7 @@ my $versionNumbersComparisons = [
 plan tests =>
     scalar (keys %system_profiler_tests) +
     scalar @ioreg_tests
-    + 14
+    + 15
     + scalar (@$versionNumbersComparisons);
 
 foreach my $test (keys %system_profiler_tests) {
@@ -3565,3 +3566,10 @@ for my $listVersionNumbers (@$versionNumbersComparisons) {
     );
 }
 ok (FusionInventory::Agent::Tools::MacOS::cmpVersionNumbers('5.34.54', '5.34.54') == 0);
+
+SKIP : {
+    skip 'MacOS specific test', 1 unless $OSNAME eq 'darwin';
+
+    my $boottime = getBootTime();
+    ok ($boottime);
+}

--- a/t/agent/tools/macos.t
+++ b/t/agent/tools/macos.t
@@ -5,6 +5,7 @@ use warnings;
 
 use Test::Deep;
 use Test::More;
+use English;
 
 use FusionInventory::Agent::Tools::MacOS;
 use FusionInventory::Agent::Task::Inventory::MacOS::Softwares;
@@ -3384,7 +3385,7 @@ my $versionNumbersComparisons = [
 plan tests =>
     scalar (keys %system_profiler_tests) +
     scalar @ioreg_tests
-    + 15
+    + 16
     + scalar (@$versionNumbersComparisons);
 
 foreach my $test (keys %system_profiler_tests) {

--- a/t/tasks/inventory/macos/uptime.t
+++ b/t/tasks/inventory/macos/uptime.t
@@ -7,6 +7,7 @@ use Test::More;
 use Test::NoWarnings;
 
 use FusionInventory::Agent::Task::Inventory::MacOS::Uptime;
+use FusionInventory::Agent::Tools::MacOS::getBootTime;
 
 my %tests = (
         '1325070226' => '1325070226',
@@ -16,6 +17,6 @@ my %tests = (
 plan tests => (scalar keys %tests) + 1;
 
 foreach my $test (keys %tests) {
- my $r = FusionInventory::Agent::Task::Inventory::MacOS::Uptime::_getBootTime(string => $test);
+ my $r = FusionInventory::Agent::Tools::MacOS::getBootTime(string => $test);
     ok($r eq $tests{$test});
 }


### PR DESCRIPTION
MacOS/Uptime.pm function named '_getBootTime' has been reused. Its content have been moved in Tools/MacOS.pm. This code has been completed to have a default value for 'command' parameter.
Add of unit test for this new function in Tools/MacOS.pm