### PR TITLE
In scalar context, Tools::GetFirstMatch() can return undef

### DIFF
--- a/lib/FusionInventory/Agent/Tools.pm
+++ b/lib/FusionInventory/Agent/Tools.pm
@@ -12,6 +12,7 @@ use File::stat;
 use File::Which;
 use Memoize;
 use UNIVERSAL::require;
+use List::Util qw(first);
 
 our @EXPORT = qw(
     getDirectoryHandle
@@ -347,7 +348,7 @@ sub getFirstMatch {
     }
     close $handle;
 
-    return wantarray ? @results : $results[0];
+    return wantarray ? @results : first {defined} @results;
 }
 
 sub getAllLines {

--- a/lib/FusionInventory/Agent/Tools.pm
+++ b/lib/FusionInventory/Agent/Tools.pm
@@ -348,7 +348,7 @@ sub getFirstMatch {
     }
     close $handle;
 
-    return wantarray ? @results : first {defined} @results;
+    return wantarray ? @results : first { defined $_ } @results;
 }
 
 sub getAllLines {


### PR DESCRIPTION
An example. 
Regex /(?: sec = (\d+)|(\d+)$)/ can return a list with an undef value. The getFirstMatch() function takes the first, even it's undef... gives unexpected result.
I propose, in scalar context, to return first defined value in list.