### PR TITLE
Excessive use directive (module needed only on Mac OS X)

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,7 +18,9 @@ requires 'Net::IP'            => '0';
 requires 'Text::Template'     => '0';
 requires 'UNIVERSAL::require' => '0';
 requires 'XML::TreePP'        => '0.26';
-requires 'Tie::IxHash'        => '0';
+if ($OSNAME =~ /darwin/i) {
+    requires 'Tie::IxHash'        => '0';
+}
 
 if ($OSNAME eq 'MSWin32') {
     requires 'Win32::OLE'         => '0';

--- a/lib/FusionInventory/Agent/Tools/MacOS.pm
+++ b/lib/FusionInventory/Agent/Tools/MacOS.pm
@@ -9,7 +9,6 @@ use Memoize;
 use POSIX 'strftime';
 use Time::Local;
 use XML::TreePP;
-use Tie::IxHash;
 
 use FusionInventory::Agent::Tools;
 
@@ -144,6 +143,15 @@ sub _pairKeyValueFromXml {
 
 sub _parseXmlStringKeepingOrder {
     my $xmlStr = shift;
+
+    # this module is required and cannot be imported by default
+    # because it's for Mac OS X only
+    my $check = eval {
+        require Tie::IxHash;
+        Tie::IxHash->import();
+        1;
+    };
+    return unless $check;
 
     my $tpp = XML::TreePP->new( use_ixhash => 1 );
     my $tree = $tpp->parse( $xmlStr );

--- a/lib/FusionInventory/Agent/Tools/MacOS.pm
+++ b/lib/FusionInventory/Agent/Tools/MacOS.pm
@@ -9,6 +9,7 @@ use Memoize;
 use POSIX 'strftime';
 use Time::Local;
 use XML::TreePP;
+use UNIVERSAL::require;
 
 use FusionInventory::Agent::Tools;
 
@@ -50,7 +51,7 @@ sub _getSystemProfilerInfosXML {
 sub _extractDataFromXmlString {
     my ($xmlStr, $logger, $localTimeOffset) = @_;
 
-    my $xmlHash = _parseXmlStringKeepingOrder($xmlStr);
+    my $xmlHash = _parseXmlStringKeepingOrder($xmlStr, $logger);
 
     my $softwaresXmlHash = _extractInterestingPartOfHash($xmlHash);
 
@@ -142,16 +143,17 @@ sub _pairKeyValueFromXml {
 }
 
 sub _parseXmlStringKeepingOrder {
-    my $xmlStr = shift;
+    my ($xmlStr, $logger) = @_;
 
     # this module is required and cannot be imported by default
     # because it's for Mac OS X only
-    my $check = eval {
-        require Tie::IxHash;
-        Tie::IxHash->import();
-        1;
-    };
-    return unless $check;
+    Tie::IxHash->require();
+    if ($EVAL_ERROR) {
+        $logger->debug(
+            'Tie::IxHash unavailable, unable launching _parseXmlStringKeepingOrder to retrieve softwares'
+        ) if $logger;
+        return 0;
+    }
 
     my $tpp = XML::TreePP->new( use_ixhash => 1 );
     my $tree = $tpp->parse( $xmlStr );

--- a/t/agent/tools/macos.t
+++ b/t/agent/tools/macos.t
@@ -6,6 +6,7 @@ use warnings;
 use Test::Deep;
 use Test::More;
 use English;
+use UNIVERSAL::require;
 
 use FusionInventory::Agent::Tools::MacOS;
 use FusionInventory::Agent::Task::Inventory::MacOS::Softwares;
@@ -3382,12 +3383,6 @@ my $versionNumbersComparisons = [
     ['5.4.2', '10.2']
 ];
 
-my $checkTieIxHash = eval {
-    require Tie::IxHash;
-    Tie::IxHash->import();
-    1;
-};
-
 plan tests =>
     scalar (keys %system_profiler_tests) +
     scalar @ioreg_tests
@@ -3411,6 +3406,9 @@ my $flatFile = 'resources/macos/system_profiler/10.8-system_profiler_SPApplicati
 my $softwaresFromFlatFile = FusionInventory::Agent::Tools::MacOS::_getSystemProfilerInfosText(file => $flatFile, type => $type);
 my $xmlFile = 'resources/macos/system_profiler/10.8-system_profiler_SPApplicationsDataType_-xml.example.xml';
 my $softwaresFromXmlFile = FusionInventory::Agent::Tools::MacOS::_getSystemProfilerInfosXML(file => $xmlFile, type => $type, localTimeOffset => 7200);
+
+Tie::IxHash->require();
+my $checkTieIxHash = $EVAL_ERROR ? 0 : 1;
 SKIP : {
     skip 'test only if module Tie::IxHash available', 2 unless $checkTieIxHash;
 


### PR DESCRIPTION
Module Tie::IxHash is required only on Mac OS X now. Inventory tools' function and unit tests run only if module can be imported at runtime.