### PR TITLE
2.3.x+provider and version refactoring

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,7 +7,7 @@ include 'Module::AutoInstall';
 abstract 'FusionInventory unified Agent for UNIX, Linux, Windows and MacOSX';
 license 'gpl';
 repository 'https://github.com/fusioninventory/fusioninventory-agent';
-version_from 'lib/FusionInventory/Agent.pm';
+version_from 'lib/FusionInventory/Agent/Version.pm';
 perl_version '5.008';
 authors 'FusionInventory Team';
 

--- a/bin/fusioninventory-agent
+++ b/bin/fusioninventory-agent
@@ -2,7 +2,9 @@
 
 use strict;
 use warnings;
-use lib './lib';
+
+use lib './bin';
+use setup;
 
 use English qw(-no_match_vars);
 use Getopt::Long;
@@ -70,13 +72,6 @@ if ($options->{version}) {
     print $FusionInventory::Agent::VERSION_STRING . "\n";
     exit 0;
 }
-
-my %setup = (
-    confdir => './etc',
-    datadir => './share',
-    libdir  => './lib',
-    vardir  => './var',
-);
 
 if ($options->{setup}) {
     foreach my $key (keys %setup) {

--- a/bin/fusioninventory-esx
+++ b/bin/fusioninventory-esx
@@ -2,7 +2,9 @@
 
 use strict;
 use warnings;
-use lib './lib';
+
+use lib './bin';
+use setup;
 
 use English qw(-no_match_vars) ;
 use Getopt::Long;

--- a/bin/fusioninventory-inventory
+++ b/bin/fusioninventory-inventory
@@ -2,7 +2,9 @@
 
 use strict;
 use warnings;
-use lib './lib';
+
+use lib './bin';
+use setup;
 
 use English qw(-no_match_vars);
 use Getopt::Long;
@@ -13,13 +15,6 @@ use FusionInventory::Agent::Task::Inventory;
 use FusionInventory::Agent::Target::Local;
 use FusionInventory::Agent::Logger;
 use FusionInventory::Agent::Config;
-
-my %setup = (
-    confdir => './etc',
-    datadir => './share',
-    libdir  => './lib',
-    vardir  => './var',
-);
 
 my $options = {
     debug  => 0,

--- a/bin/fusioninventory-netdiscovery
+++ b/bin/fusioninventory-netdiscovery
@@ -2,7 +2,9 @@
 
 use strict;
 use warnings;
-use lib './lib';
+
+use lib './bin';
+use setup;
 
 use English qw(-no_match_vars);
 use Getopt::Long;
@@ -15,13 +17,6 @@ my $options = {
     debug   => 0,
     threads => 1
 };
-
-my %setup = (
-    confdir => './etc',
-    datadir => './share',
-    libdir  => './lib',
-    vardir  => './var',
-);
 
 GetOptions(
     $options,

--- a/bin/fusioninventory-netinventory
+++ b/bin/fusioninventory-netinventory
@@ -2,7 +2,9 @@
 
 use strict;
 use warnings;
-use lib './lib';
+
+use lib './bin';
+use setup;
 
 use English qw(-no_match_vars);
 use Getopt::Long;
@@ -27,13 +29,6 @@ my $options = {
     debug => 0,
     threads => 1
 };
-
-my %setup = (
-    confdir => './etc',
-    datadir => './share',
-    libdir  => './lib',
-    vardir  => './var',
-);
 
 GetOptions(
     $options,

--- a/bin/fusioninventory-wakeonlan
+++ b/bin/fusioninventory-wakeonlan
@@ -2,7 +2,9 @@
 
 use strict;
 use warnings;
-use lib './lib';
+
+use lib './bin';
+use setup;
 
 use English qw(-no_match_vars);
 use Getopt::Long;

--- a/bin/setup.pm
+++ b/bin/setup.pm
@@ -1,0 +1,35 @@
+package setup;
+
+use strict;
+use warnings;
+use base qw(Exporter);
+
+our @EXPORT = ('%setup');
+
+our %setup;
+
+# From here we can setup @INC so any needed perl module can be found. We add
+# as many 'use lib' directive as needed
+# We could also define '%setup' hash while useful
+
+# Here is a sample working from sources directory or its bin subfolder
+if (-d 'lib') {
+    use lib './lib' ;
+
+    %setup = (
+        confdir => './etc',
+        datadir => './share',
+        libdir  => './lib',
+        vardir  => './var',
+    );
+
+} elsif (-d '../lib') {
+    use lib '../lib';
+
+    %setup = (
+        confdir => '../etc',
+        datadir => '../share',
+        libdir  => '../lib',
+        vardir  => '../var',
+    );
+}

--- a/lib/FusionInventory/Agent.pm
+++ b/lib/FusionInventory/Agent.pm
@@ -32,7 +32,7 @@ sub _versionString {
     my ($VERSION) = @_;
 
     my $string = "$PROVIDER Agent ($VERSION)";
-    if ($VERSION =~ /^\d+\.\d+(\.99\d\d|\d+-dev)$/) {
+    if ($VERSION =~ /^\d+\.\d+\.(99\d\d|\d+-dev)$/) {
         $string .= " **THIS IS A DEVELOPMENT RELEASE **";
     }
 

--- a/lib/FusionInventory/Agent.pm
+++ b/lib/FusionInventory/Agent.pm
@@ -444,9 +444,9 @@ sub getAvailableTasks {
     my $directory = $self->{libdir};
     $directory =~ s,\\,/,g;
     my $subdirectory = "FusionInventory/Agent/Task";
-    # look for all perl modules here
-    foreach my $file (File::Glob::glob("$directory/$subdirectory/*.pm")) {
-        next unless $file =~ m{($subdirectory/(\S+)\.pm)$};
+    # look for all Version perl modules around here
+    foreach my $file (File::Glob::glob("$directory/$subdirectory/*/Version.pm")) {
+        next unless $file =~ m{($subdirectory/(\S+)/Version\.pm)$};
         my $module = file2module($1);
         my $name = file2module($2);
 
@@ -502,15 +502,10 @@ sub _getTaskVersion {
         return;
     }
 
-    if (!$module->isa('FusionInventory::Agent::Task')) {
-        $logger->debug2("module $module is not a task") if $logger;
-        return;
-    }
-
     my $version;
     {
         no strict 'refs';  ## no critic
-        $version = ${$module . '::VERSION'};
+        $version = &{$module . '::VERSION'};
     }
 
     return $version;

--- a/lib/FusionInventory/Agent/Config.pm
+++ b/lib/FusionInventory/Agent/Config.pm
@@ -8,6 +8,8 @@ use File::Spec;
 use Getopt::Long;
 use UNIVERSAL::require;
 
+use FusionInventory::Agent::Version;
+
 require FusionInventory::Agent::Tools;
 
 my $default = {
@@ -143,7 +145,8 @@ sub _loadFromRegistry {
         Access => Win32::TieRegistry::KEY_READ()
     }) or die "Can't open HKEY_LOCAL_MACHINE key: $EXTENDED_OS_ERROR";
 
-    my $settings = $machKey->{"SOFTWARE/FusionInventory-Agent"};
+    my $provider = $FusionInventory::Agent::Version::PROVIDER;
+    my $settings = $machKey->{"SOFTWARE/$provider-Agent"};
 
     foreach my $rawKey (keys %$settings) {
         next unless $rawKey =~ /^\/(\S+)/;

--- a/lib/FusionInventory/Agent/HTTP/Server.pm
+++ b/lib/FusionInventory/Agent/HTTP/Server.pm
@@ -12,6 +12,7 @@ use Text::Template;
 use File::Glob;
 use URI;
 
+use FusionInventory::Agent::Version;
 use FusionInventory::Agent::Logger;
 use FusionInventory::Agent::Tools::Network;
 
@@ -147,7 +148,7 @@ sub _handle_root {
         $self->{agent}->getTargets();
 
     my $hash = {
-        version        => $FusionInventory::Agent::VERSION,
+        version        => $FusionInventory::Agent::Version::VERSION,
         trust          => $self->_isTrusted($clientIp),
         status         => $self->{agent}->getStatus(),
         server_targets => \@server_targets,

--- a/lib/FusionInventory/Agent/Inventory.pm
+++ b/lib/FusionInventory/Agent/Inventory.pm
@@ -10,6 +10,7 @@ use English qw(-no_match_vars);
 use XML::TreePP;
 
 use FusionInventory::Agent::Tools;
+use FusionInventory::Agent::Version;
 
 my %fields = (
     BIOS             => [ qw/SMODEL SMANUFACTURER SSN BDATE BVERSION
@@ -126,7 +127,8 @@ sub new {
                 ARCHNAME => $Config{archname},
                 VMSYSTEM => "Physical" # Default value
             },
-            VERSIONCLIENT => $FusionInventory::Agent::AGENT_STRING
+            VERSIONCLIENT => $FusionInventory::Agent::AGENT_STRING ||
+                $FusionInventory::Agent::Version::PROVIDER."-Inventory_v".$FusionInventory::Agent::Version::VERSION
         }
     };
     bless $self, $class;

--- a/lib/FusionInventory/Agent/Logger.pm
+++ b/lib/FusionInventory/Agent/Logger.pm
@@ -124,7 +124,7 @@ __END__
 
 =head1 NAME
 
-FusionInventory::Agent::Logger - Fusion Inventory logger
+FusionInventory::Agent::Logger - FusionInventory logger
 
 =head1 DESCRIPTION
 

--- a/lib/FusionInventory/Agent/Task/Collect.pm
+++ b/lib/FusionInventory/Agent/Task/Collect.pm
@@ -15,7 +15,9 @@ use FusionInventory::Agent::Logger;
 use FusionInventory::Agent::Tools;
 use FusionInventory::Agent::HTTP::Client::Fusion;
 
-our $VERSION = $FusionInventory::Agent::VERSION;
+use FusionInventory::Agent::Task::Collect::Version;
+
+our $VERSION = FusionInventory::Agent::Task::Collect::Version::VERSION;
 
 my %functions = (
     getFromRegistry => \&_getFromRegistry,

--- a/lib/FusionInventory/Agent/Task/Collect/Version.pm
+++ b/lib/FusionInventory/Agent/Task/Collect/Version.pm
@@ -1,0 +1,8 @@
+package FusionInventory::Agent::Task::Collect::Version;
+
+use strict;
+use warnings;
+
+use constant VERSION => "2.4.0";
+
+1;

--- a/lib/FusionInventory/Agent/Task/Deploy.pm
+++ b/lib/FusionInventory/Agent/Task/Deploy.pm
@@ -19,7 +19,9 @@ use FusionInventory::Agent::Task::Deploy::Datastore;
 use FusionInventory::Agent::Task::Deploy::File;
 use FusionInventory::Agent::Task::Deploy::Job;
 
-our $VERSION = '2.1.0';
+use FusionInventory::Agent::Task::Deploy::Version;
+
+our $VERSION = FusionInventory::Agent::Task::Deploy::Version::VERSION;
 
 sub isEnabled {
     my ($self) = @_;

--- a/lib/FusionInventory/Agent/Task/Deploy/Version.pm
+++ b/lib/FusionInventory/Agent/Task/Deploy/Version.pm
@@ -1,0 +1,8 @@
+package FusionInventory::Agent::Task::Deploy::Version;
+
+use strict;
+use warnings;
+
+use constant VERSION => "2.1.1";
+
+1;

--- a/lib/FusionInventory/Agent/Task/Inventory.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory.pm
@@ -12,7 +12,9 @@ use FusionInventory::Agent::Tools;
 use FusionInventory::Agent::Inventory;
 use FusionInventory::Agent::XML::Query::Inventory;
 
-our $VERSION = '1.0';
+use FusionInventory::Agent::Task::Inventory::Version;
+
+our $VERSION = FusionInventory::Agent::Task::Inventory::Version::VERSION;
 
 sub isEnabled {
     my ($self, $response) = @_;
@@ -153,6 +155,12 @@ sub _initModulesList {
         my @components = split('::', $module);
         my $parent = @components > 5 ?
             join('::', @components[0 .. $#components -1]) : '';
+
+        # Just skip Version package as not an inventory package module
+        if ($module =~ /FusionInventory::Agent::Task::Inventory::Version$/) {
+            $self->{modules}->{$module}->{enabled} = 0;
+            next;
+        }
 
         # skip if parent is not allowed
         if ($parent && !$self->{modules}->{$parent}->{enabled}) {
@@ -357,7 +365,7 @@ sub _printInventory {
             );
 
              my $hash = {
-                version  => $FusionInventory::Agent::VERSION,
+                version  => $FusionInventory::Agent::Version::VERSION,
                 deviceid => $params{inventory}->{deviceid},
                 data     => $params{inventory}->{content},
                 fields   => $params{inventory}->{fields},

--- a/lib/FusionInventory/Agent/Task/Inventory/Version.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Version.pm
@@ -1,0 +1,8 @@
+package FusionInventory::Agent::Task::Inventory::Version;
+
+use strict;
+use warnings;
+
+use constant VERSION => "1.1";
+
+1;

--- a/lib/FusionInventory/Agent/Task/NetDiscovery.pm
+++ b/lib/FusionInventory/Agent/Task/NetDiscovery.pm
@@ -15,6 +15,7 @@ use Thread::Queue v2.01;
 use UNIVERSAL::require;
 use XML::TreePP;
 
+use FusionInventory::Agent::Version;
 use FusionInventory::Agent::Tools;
 use FusionInventory::Agent::Tools::Network;
 use FusionInventory::Agent::Tools::Hardware;
@@ -492,7 +493,7 @@ sub _sendStartMessage {
     $self->_sendMessage({
         AGENT => {
             START        => 1,
-            AGENTVERSION => $FusionInventory::Agent::VERSION,
+            AGENTVERSION => $FusionInventory::Agent::Version::VERSION,
         },
         MODULEVERSION => $VERSION,
         PROCESSNUMBER => $self->{pid}

--- a/lib/FusionInventory/Agent/Task/NetDiscovery.pm
+++ b/lib/FusionInventory/Agent/Task/NetDiscovery.pm
@@ -20,7 +20,9 @@ use FusionInventory::Agent::Tools::Network;
 use FusionInventory::Agent::Tools::Hardware;
 use FusionInventory::Agent::XML::Query;
 
-our $VERSION = '2.2.1';
+use FusionInventory::Agent::Task::NetDiscovery::Version;
+
+our $VERSION = FusionInventory::Agent::Task::NetDiscovery::Version::VERSION;
 
 sub isEnabled {
     my ($self, $response) = @_;

--- a/lib/FusionInventory/Agent/Task/NetDiscovery/Version.pm
+++ b/lib/FusionInventory/Agent/Task/NetDiscovery/Version.pm
@@ -1,0 +1,8 @@
+package FusionInventory::Agent::Task::NetDiscovery::Version;
+
+use strict;
+use warnings;
+
+use constant VERSION => "2.2.2";
+
+1;

--- a/lib/FusionInventory/Agent/Task/NetInventory.pm
+++ b/lib/FusionInventory/Agent/Task/NetInventory.pm
@@ -16,7 +16,9 @@ use FusionInventory::Agent::Tools;
 use FusionInventory::Agent::Tools::Hardware;
 use FusionInventory::Agent::Tools::Network;
 
-our $VERSION = '2.2.1';
+use FusionInventory::Agent::Task::NetInventory::Version;
+
+our $VERSION = FusionInventory::Agent::Task::NetInventory::Version::VERSION;
 
 # list of devices properties, indexed by XML element name
 # the link to a specific OID is made by the model

--- a/lib/FusionInventory/Agent/Task/NetInventory.pm
+++ b/lib/FusionInventory/Agent/Task/NetInventory.pm
@@ -12,6 +12,7 @@ use Thread::Queue v2.01;
 use UNIVERSAL::require;
 
 use FusionInventory::Agent::XML::Query;
+use FusionInventory::Agent::Version;
 use FusionInventory::Agent::Tools;
 use FusionInventory::Agent::Tools::Hardware;
 use FusionInventory::Agent::Tools::Network;
@@ -240,7 +241,7 @@ sub _sendStartMessage {
     $self->_sendMessage({
         AGENT => {
             START        => 1,
-            AGENTVERSION => $FusionInventory::Agent::VERSION,
+            AGENTVERSION => $FusionInventory::Agent::Version::VERSION,
         },
         MODULEVERSION => $VERSION,
         PROCESSNUMBER => $self->{pid}

--- a/lib/FusionInventory/Agent/Task/NetInventory/Version.pm
+++ b/lib/FusionInventory/Agent/Task/NetInventory/Version.pm
@@ -1,0 +1,8 @@
+package FusionInventory::Agent::Task::NetInventory::Version;
+
+use strict;
+use warnings;
+
+use constant VERSION => "2.2.2";
+
+1;

--- a/lib/FusionInventory/Agent/Task/WakeOnLan.pm
+++ b/lib/FusionInventory/Agent/Task/WakeOnLan.pm
@@ -12,7 +12,9 @@ use UNIVERSAL::require;
 use FusionInventory::Agent::Tools;
 use FusionInventory::Agent::Tools::Network;
 
-our $VERSION = '2.0';
+use FusionInventory::Agent::Task::WakeOnLan::Version;
+
+our $VERSION = FusionInventory::Agent::Task::WakeOnLan::Version::VERSION;
 
 sub isEnabled {
     my ($self, $response) = @_;

--- a/lib/FusionInventory/Agent/Task/WakeOnLan/Version.pm
+++ b/lib/FusionInventory/Agent/Task/WakeOnLan/Version.pm
@@ -1,0 +1,8 @@
+package FusionInventory::Agent::Task::WakeOnLan::Version;
+
+use strict;
+use warnings;
+
+use constant VERSION => "2.1";
+
+1;

--- a/lib/FusionInventory/Agent/Version.pm
+++ b/lib/FusionInventory/Agent/Version.pm
@@ -1,0 +1,25 @@
+package FusionInventory::Agent::Version;
+
+use strict;
+use warnings;
+
+our $VERSION = "2.3.19-dev";
+our $PROVIDER = "FusionInventory";
+
+1;
+
+__END__
+
+=head1 NAME
+
+FusionInventory::Agent::Version - FusionInventory agent version
+
+=head1 DESCRIPTION
+
+This module has the only purpose to simplify the way the FusionInventory agent
+is released. This file could be automatically generated and overriden during
+packaging.
+
+It permits to re-define agent VERSION and agent PROVIDER during packaging so
+any distributor can simplify his distribution process and permit to identify
+clearly the origin of the agent.

--- a/t/agent/agent.t
+++ b/t/agent/agent.t
@@ -13,7 +13,7 @@ use Test::More;
 use FusionInventory::Agent;
 use FusionInventory::Agent::Config;
 
-plan tests => 5 + 19 + 11 + 1;
+plan tests => 4 + 19 + 11 + 1;
 
 my $libdir = tempdir(CLEANUP => $ENV{TEST_DEBUG} ? 0 : 1);
 push @INC, $libdir;
@@ -21,10 +21,10 @@ my $agent = FusionInventory::Agent->new(libdir => $libdir);
 
 my %tasks;
 
-create_file("$libdir/FusionInventory/Agent/Task", "Task1.pm", <<'EOF');
-package FusionInventory::Agent::Task::Task1;
-use base qw(FusionInventory::Agent::Task);
-our $VERSION = 42;
+create_file("$libdir/FusionInventory/Agent/Task/Task1", "Version.pm", <<'EOF');
+package FusionInventory::Agent::Task::Task1::Version;
+use constant VERSION => 42;
+1;
 EOF
 %tasks = $agent->getAvailableTasks();
 cmp_deeply (
@@ -33,10 +33,10 @@ cmp_deeply (
     "single task"
 );
 
-create_file("$libdir/FusionInventory/Agent/Task", "Task2.pm", <<'EOF');
-package FusionInventory::Agent::Task::Task2;
-use base qw(FusionInventory::Agent::Task);
-our $VERSION = 42;
+create_file("$libdir/FusionInventory/Agent/Task/Task2", "Version.pm", <<'EOF');
+package FusionInventory::Agent::Task::Task2::Version;
+use constant VERSION => 42;
+1;
 EOF
 %tasks = $agent->getAvailableTasks();
 cmp_deeply (
@@ -48,11 +48,11 @@ cmp_deeply (
     "multiple tasks"
 );
 
-create_file("$libdir/FusionInventory/Agent/Task", "Task3.pm", <<'EOF');
-package FusionInventory::Agent::Task::Task3;
-use base qw(FusionInventory::Agent::Task;
+create_file("$libdir/FusionInventory/Agent/Task/Task3", "Version.pm", <<'EOF');
+package FusionInventory::Agent::Task::Task3::Version;
 use Does::Not::Exists;
-our $VERSION = 42;
+use constant VERSION => 42;
+1;
 EOF
 %tasks = $agent->getAvailableTasks();
 cmp_deeply(
@@ -64,24 +64,10 @@ cmp_deeply(
     "wrong syntax"
 );
 
-create_file("$libdir/FusionInventory/Agent/Task", "Test4.pm", <<'EOF');
-package FusionInventory::Agent::Task::Test4;
-our $VERSION = 42;
-EOF
-%tasks = $agent->getAvailableTasks();
-cmp_deeply(
-    \%tasks,
-    {
-        'Task1' => 42,
-        'Task2' => 42
-    },
-    "wrong class"
-);
-
-create_file("$libdir/FusionInventory/Agent/Task", "Task5.pm", <<'EOF');
-package FusionInventory::Agent::Task::Task5;
-use base qw(FusionInventory::Agent::Task);
-our $VERSION = 42;
+create_file("$libdir/FusionInventory/Agent/Task/Task5", "Version.pm", <<'EOF');
+package FusionInventory::Agent::Task::Task5::Version;
+use constant VERSION => 42;
+1;
 EOF
 %tasks = $agent->getAvailableTasks();
 cmp_deeply (

--- a/t/agent/xml/query/inventory.t
+++ b/t/agent/xml/query/inventory.t
@@ -9,6 +9,7 @@ use Test::Exception;
 use Test::More;
 use XML::TreePP;
 
+use FusionInventory::Agent::Version;
 use FusionInventory::Agent::Inventory;
 use FusionInventory::Agent::XML::Query::Inventory;
 
@@ -30,6 +31,7 @@ lives_ok {
 isa_ok($query, 'FusionInventory::Agent::XML::Query::Inventory');
 
 my $tpp = XML::TreePP->new();
+my $AgentString = $FusionInventory::Agent::Version::PROVIDER."-Inventory_v".$FusionInventory::Agent::Version::VERSION;
 
 cmp_deeply(
     scalar $tpp->parse($query->getContent()),
@@ -42,7 +44,7 @@ cmp_deeply(
                     ARCHNAME => $Config{archname},
                     VMSYSTEM => 'Physical'
                 },
-                VERSIONCLIENT => $FusionInventory::Agent::AGENT_STRING,
+                VERSIONCLIENT => $AgentString,
             },
         }
     },
@@ -72,7 +74,7 @@ cmp_deeply(
                     ARCHNAME => $Config{archname},
                     VMSYSTEM => 'Physical'
                 },
-                VERSIONCLIENT => $FusionInventory::Agent::AGENT_STRING,
+                VERSIONCLIENT => $AgentString,
                 SOFTWARES => {
                     NAME => '<&>'
                 }


### PR DESCRIPTION
Full refactoring of version handling. "FusionInventory" is defined as a PROVIDER constant so the agent could be also used as a SDK.
* This will simplify release process limiting the need to "patch" sources in some case.
* Refactoring on the way task versions are read will reduce memory footprint in daemon and service mode