### PR TITLE
2.3.x+service optimizations

### DIFF
--- a/lib/FusionInventory/Agent.pm
+++ b/lib/FusionInventory/Agent.pm
@@ -237,6 +237,13 @@ sub ApplyServiceOptimizations {
         getUSBDeviceVendor(datadir => $self->{datadir});
         getEDIDVendor(datadir => $self->{datadir});
     }
+
+    # win32 platform optimization
+    if ($OSNAME ne 'MSWin32') {
+        # Preload is64bit result to avoid a lot of WMI calls
+        FusionInventory::Agent::Tools::Win32->require();
+        FusionInventory::Agent::Tools::Win32::is64bit();
+    }
 }
 
 sub run {

--- a/lib/FusionInventory/Agent.pm
+++ b/lib/FusionInventory/Agent.pm
@@ -246,6 +246,16 @@ sub ApplyServiceOptimizations {
     }
 }
 
+sub RunningServiceOptimization {
+    my ($self) = @_;
+
+    # win32 platform needs optimization
+    if ($OSNAME ne 'MSWin32') {
+        my $current_mem = FusionInventory::Agent::Tools::Win32::getAgentMemorySize();
+        $self->{logger}->log("Agent memory usage: $current_mem");
+    }
+}
+
 sub run {
     my ($self) = @_;
 
@@ -277,6 +287,9 @@ sub run {
 
                 # Leave immediately if we passed in terminate method
                 last unless $self->getTargets();
+
+                # Call service optimization after each target run
+                $self->RunningServiceOptimization();
             }
 
             if ($self->{server}) {

--- a/lib/FusionInventory/Agent.pm
+++ b/lib/FusionInventory/Agent.pm
@@ -251,6 +251,13 @@ sub RunningServiceOptimization {
 
     # win32 platform needs optimization
     if ($OSNAME ne 'MSWin32') {
+        if ($self->{logger}->{verbosity} >= LOG_DEBUG) {
+            my $runmem = FusionInventory::Agent::Tools::Win32::getAgentMemorySize();
+            $self->{logger}->debug("Agent memory usage before freeing memory: $runmem");
+        }
+
+        FusionInventory::Agent::Tools::Win32::FreeAgentMem();
+
         my $current_mem = FusionInventory::Agent::Tools::Win32::getAgentMemorySize();
         $self->{logger}->log("Agent memory usage: $current_mem");
     }

--- a/lib/FusionInventory/Agent.pm
+++ b/lib/FusionInventory/Agent.pm
@@ -259,7 +259,7 @@ sub RunningServiceOptimization {
         FusionInventory::Agent::Tools::Win32::FreeAgentMem();
 
         my $current_mem = FusionInventory::Agent::Tools::Win32::getAgentMemorySize();
-        $self->{logger}->log("Agent memory usage: $current_mem");
+        $self->{logger}->info("Agent memory usage: $current_mem");
     }
 }
 

--- a/lib/FusionInventory/Agent.pm
+++ b/lib/FusionInventory/Agent.pm
@@ -239,7 +239,7 @@ sub ApplyServiceOptimizations {
     }
 
     # win32 platform optimization
-    if ($OSNAME ne 'MSWin32') {
+    if ($OSNAME eq 'MSWin32') {
         # Preload is64bit result to avoid a lot of WMI calls
         FusionInventory::Agent::Tools::Win32->require();
         FusionInventory::Agent::Tools::Win32::is64bit();
@@ -250,7 +250,7 @@ sub RunningServiceOptimization {
     my ($self) = @_;
 
     # win32 platform needs optimization
-    if ($OSNAME ne 'MSWin32') {
+    if ($OSNAME eq 'MSWin32') {
         if ($self->{logger}->{verbosity} >= LOG_DEBUG) {
             my $runmem = FusionInventory::Agent::Tools::Win32::getAgentMemorySize();
             $self->{logger}->debug("Agent memory usage before freeing memory: $runmem");

--- a/lib/FusionInventory/Agent/Tools.pm
+++ b/lib/FusionInventory/Agent/Tools.pm
@@ -50,7 +50,7 @@ our @EXPORT = qw(
 
 my $nowhere = $OSNAME eq 'MSWin32' ? 'nul' : '/dev/null';
 
-# this trigger some errors on Perl 5.12/Win32:
+# this trigger some errors under win32:
 # Anonymous function called in forbidden scalar context
 if ($OSNAME ne 'MSWin32') {
     memoize('canRun');

--- a/lib/FusionInventory/Agent/Tools/Generic.pm
+++ b/lib/FusionInventory/Agent/Tools/Generic.pm
@@ -27,8 +27,12 @@ my $USBVendors;
 my $USBClasses;
 my $EDIDVendors;
 
-memoize('getDmidecodeInfos');
-memoize('getPCIDevices');
+# this trigger some errors under Win32:
+# Anonymous function called in forbidden scalar context
+if ($OSNAME ne 'MSWin32') {
+    memoize('getDmidecodeInfos');
+    memoize('getPCIDevices');
+}
 
 sub getDmidecodeInfos {
     my (%params) = (

--- a/lib/FusionInventory/Agent/Tools/Win32.pm
+++ b/lib/FusionInventory/Agent/Tools/Win32.pm
@@ -46,8 +46,12 @@ our @EXPORT = qw(
     getUsersFromRegistry
 );
 
+my $_is64bits = undef;
 sub is64bit {
-    return
+    # Cache is64bit() result in a private module variable to avoid a lot of wmi
+    # calls and as this value won't change during the service/task lifetime
+    return $_is64bits if $_is64bits;
+    return $_is64bits =
         any { $_->{AddressWidth} eq 64 }
         getWMIObjects(
             class => 'Win32_Processor', properties => [ qw/AddressWidth/ ]


### PR DESCRIPTION
This PR concerns mostly Win32 platform. For other platforms, only the IDS databases preload is relevant.
The most important is an attempt to limit the memory usage under win32.