### PR TITLE
OSX: really call Hostname.pm from MacOS, switch to scutil and fallback to hostname() if ComputerName is empty

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/Generic/Hostname.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Generic/Hostname.pm
@@ -10,6 +10,9 @@ use Sys::Hostname;
 use FusionInventory::Agent::Tools;
 
 sub isEnabled {
+    # We use scutil to get the ComputerName
+    return 0 if $OSNAME eq 'darwin';
+
     # We use WMI for Windows because of charset issue
     return $OSNAME ne 'MSWin32';
 }

--- a/lib/FusionInventory/Agent/Task/Inventory/MacOS/Hostname.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/MacOS/Hostname.pm
@@ -1,29 +1,37 @@
 package FusionInventory::Agent::Task::Inventory::MacOS::Hostname;
 
+use English qw(-no_match_vars);
+
 use strict;
 use warnings;
+
+use Sys::Hostname;
 
 use FusionInventory::Agent::Tools;
 use FusionInventory::Agent::Tools::MacOS;
 
 sub isEnabled {
-    return canRun('/usr/sbin/system_profiler');
+    return 1 if $OSNAME eq 'darwin';
 }
 
 sub doInventory {
     my (%params) = @_;
 
     my $inventory = $params{inventory};
-    my $logger    = $params{logger};
 
-    my $infos = getSystemProfilerInfos(type => 'SPApplicationsDataType', logger => $logger);
+    $inventory->setHardware({NAME => _gethostname()});
+}
 
-    my $hostname =
-        $infos->{'Software'}->{'System Software Overview'}->{'Computer Name'};
+sub _gethostname {
 
-    $inventory->setHardware({
-        NAME => $hostname
-    }) if $hostname;
+    my $computername = getFirstLine(command => 'scutil --get ComputerName');
+
+    if ($computername eq ""){
+        $computername = hostname();
+        $computername =~ s/\..*//; # keep just the hostname
+    }
+    return $computername
+
 }
 
 1;

--- a/lib/FusionInventory/Agent/Task/Inventory/MacOS/Hostname.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/MacOS/Hostname.pm
@@ -11,7 +11,7 @@ use FusionInventory::Agent::Tools;
 use FusionInventory::Agent::Tools::MacOS;
 
 sub isEnabled {
-    return 1 if $OSNAME eq 'darwin';
+    return canRun('/usr/bin/scutil');
 }
 
 sub doInventory {


### PR DESCRIPTION
This will fix issue #198 
The existing code in MacOS.pm was never called, and wasn't working as excepted
