### PR TITLE
Mac addresses connected to a port when has already been identified through CDP/LLDP.

### DIFF
--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -1031,12 +1031,6 @@ sub _addKnownMacAddresses {
 
         my $port = $ports->{$port_id};
 
-        # connected device has already been identified through CDP/LLDP
-        #next if (comment because we need the mac's for PHONE-PC connection)
-        #    exists $port->{CONNECTIONS} &&
-        #    exists $port->{CONNECTIONS}->{CDP} &&
-        #    $port->{CONNECTIONS}->{CDP};
-
         # get at list of already associated addresses, if any
         # as well as the port own mac address, if known
         my @known;

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -1032,10 +1032,10 @@ sub _addKnownMacAddresses {
         my $port = $ports->{$port_id};
 
         # connected device has already been identified through CDP/LLDP
-        next if
-            exists $port->{CONNECTIONS} &&
-            exists $port->{CONNECTIONS}->{CDP} &&
-            $port->{CONNECTIONS}->{CDP};
+        #next if (comment because we need the mac's for PHONE-PC connection)
+        #    exists $port->{CONNECTIONS} &&
+        #    exists $port->{CONNECTIONS}->{CDP} &&
+        #    $port->{CONNECTIONS}->{CDP};
 
         # get at list of already associated addresses, if any
         # as well as the port own mac address, if known


### PR DESCRIPTION
Fix to view mac addresses connected to a port when has already been identified through CDP/LLDP.