### PR TITLE
Support HOSTID on OPERATINGSYSTEM node for linux & solaris inventory

### DIFF
--- a/lib/FusionInventory/Agent/Inventory.pm
+++ b/lib/FusionInventory/Agent/Inventory.pm
@@ -25,7 +25,7 @@ my %fields = (
                              WINPRODKEY WINCOMPANY WINLANG CHASSIS_TYPE
                              VMNAME VMHOSTSERIAL/ ],
     OPERATINGSYSTEM  => [ qw/KERNEL_NAME KERNEL_VERSION NAME VERSION FULL_NAME
-                             SERVICE_PACK INSTALL_DATE FQDN DNS_DOMAIN
+                             SERVICE_PACK INSTALL_DATE FQDN DNS_DOMAIN HOSTID
                              SSH_KEY ARCH BOOT_TIME TIMEZONE/ ],
     ACCESSLOG        => [ qw/USERID LOGDATE/ ],
 

--- a/lib/FusionInventory/Agent/Task/Inventory/Linux.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Linux.pm
@@ -24,6 +24,7 @@ sub doInventory {
     my $kernelRelease = getFirstLine(command => 'uname -r');
 
     my $systemId  = _getRHNSystemId('/etc/sysconfig/rhn/systemid');
+    my $hostid = getFirstLine(command => 'hostid');
 
     my $boottime =
         time - getFirstMatch(file => '/proc/uptime', pattern => qr/^(\d+)/);
@@ -35,6 +36,7 @@ sub doInventory {
     });
 
     $inventory->setOperatingSystem({
+        HOSTID         => $hostid,
         KERNEL_VERSION => $kernelRelease,
         BOOT_TIME      => getFormatedLocalTime($boottime)
     });

--- a/lib/FusionInventory/Agent/Task/Inventory/Solaris.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Solaris.pm
@@ -37,6 +37,7 @@ sub doInventory {
 
     $inventory->setOperatingSystem({
         NAME           => "Solaris",
+        HOSTID         => $hostid,
         FULL_NAME      => $info->{fullname},
         VERSION        => $info->{version},
         SERVICE_PACK   => $info->{subversion},


### PR DESCRIPTION
hostid command output is sometime required for proprietary software licensing