### PR TITLE
must check if key contains subkeys

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/Generic/Remote_Mgmt/TeamViewer.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Generic/Remote_Mgmt/TeamViewer.pm
@@ -20,7 +20,7 @@ sub isEnabled {
                 "HKEY_LOCAL_MACHINE/SOFTWARE/TeamViewer",
             logger => $params{logger}
         );
-		return $key && (keys %$key);
+        return $key && (keys %$key);
     } elsif ($OSNAME eq 'darwin') {
         return canRun('defaults') && grep { -e $_ } map {
             "/Library/Preferences/com.teamviewer.teamviewer$_.plist"

--- a/lib/FusionInventory/Agent/Task/Inventory/Generic/Remote_Mgmt/TeamViewer.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Generic/Remote_Mgmt/TeamViewer.pm
@@ -14,7 +14,6 @@ sub isEnabled {
 
         FusionInventory::Agent::Tools::Win32->use();
 
-		$DB::single = 1;
         my $key = getRegistryKey(
             path => is64bit() ?
                 "HKEY_LOCAL_MACHINE/SOFTWARE/Wow6432Node/TeamViewer" :

--- a/lib/FusionInventory/Agent/Task/Inventory/Generic/Remote_Mgmt/TeamViewer.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Generic/Remote_Mgmt/TeamViewer.pm
@@ -14,12 +14,14 @@ sub isEnabled {
 
         FusionInventory::Agent::Tools::Win32->use();
 
-        return defined getRegistryKey(
+		$DB::single = 1;
+        my $key = getRegistryKey(
             path => is64bit() ?
                 "HKEY_LOCAL_MACHINE/SOFTWARE/Wow6432Node/TeamViewer" :
                 "HKEY_LOCAL_MACHINE/SOFTWARE/TeamViewer",
             logger => $params{logger}
         );
+		return $key && (keys %$key);
     } elsif ($OSNAME eq 'darwin') {
         return canRun('defaults') && grep { -e $_ } map {
             "/Library/Preferences/com.teamviewer.teamviewer$_.plist"


### PR DESCRIPTION
TeamViewer test is failing on Win32. 
It's when TeamViewer has been uninstalled. The key TeamViewer is still present in registry but empty. 
Our test to see if module is enabled was not sufficient so I had a check to see if the key contains subkeys. 