### PR TITLE
Target API refactoring to avoid minor issue

### DIFF
--- a/lib/FusionInventory/Agent.pm
+++ b/lib/FusionInventory/Agent.pm
@@ -300,7 +300,7 @@ sub run {
                 $self->{logger}->error($EVAL_ERROR) if $EVAL_ERROR;
                 if ($net_error) {
                     # Prefer to retry early on net error
-                    $target->setNextRunDate($target->getNextRunDate()+60);
+                    $target->runFromNow(60);
                 } else {
                     $target->resetNextRunDate();
                 }

--- a/lib/FusionInventory/Agent.pm
+++ b/lib/FusionInventory/Agent.pm
@@ -339,6 +339,9 @@ sub run {
                 $self->_runTarget($target);
             };
             $self->{logger}->error($EVAL_ERROR) if $EVAL_ERROR;
+
+            # Reset next run date to support --lazy option with foreground mode
+            $target->resetNextRunDate();
         }
     }
 }

--- a/lib/FusionInventory/Agent.pm
+++ b/lib/FusionInventory/Agent.pm
@@ -300,7 +300,7 @@ sub run {
                 $self->{logger}->error($EVAL_ERROR) if $EVAL_ERROR;
                 if ($net_error) {
                     # Prefer to retry early on net error
-                    $target->runFromNow(60);
+                    $target->setNextRunDateFromNow(60);
                 } else {
                     $target->resetNextRunDate();
                 }

--- a/lib/FusionInventory/Agent/HTTP/Server.pm
+++ b/lib/FusionInventory/Agent/HTTP/Server.pm
@@ -217,7 +217,7 @@ sub _handle_now {
             my $url       = $target->getUrl();
             my $addresses = $self->{trust}->{$url};
             next unless isPartOf($clientIp, $addresses, $logger);
-            $target->setNextRunDate(1);
+            $target->runFromNow();
             $code    = 200;
             $message = "OK";
             $trace   = "rescheduling next contact for target $url right now";
@@ -226,7 +226,7 @@ sub _handle_now {
 
         if ($self->_isTrusted($clientIp)) {
             foreach my $target ($self->{agent}->getTargets()) {
-                $target->setNextRunDate(1);
+                $target->runFromNow();
             }
             $code    = 200;
             $message = "OK";

--- a/lib/FusionInventory/Agent/HTTP/Server.pm
+++ b/lib/FusionInventory/Agent/HTTP/Server.pm
@@ -217,7 +217,7 @@ sub _handle_now {
             my $url       = $target->getUrl();
             my $addresses = $self->{trust}->{$url};
             next unless isPartOf($clientIp, $addresses, $logger);
-            $target->runFromNow();
+            $target->setNextRunDateFromNow();
             $code    = 200;
             $message = "OK";
             $trace   = "rescheduling next contact for target $url right now";
@@ -226,7 +226,7 @@ sub _handle_now {
 
         if ($self->_isTrusted($clientIp)) {
             foreach my $target ($self->{agent}->getTargets()) {
-                $target->runFromNow();
+                $target->setNextRunDateFromNow();
             }
             $code    = 200;
             $message = "OK";

--- a/lib/FusionInventory/Agent/Target.pm
+++ b/lib/FusionInventory/Agent/Target.pm
@@ -66,7 +66,7 @@ sub setNextRunDate {
     $self->_saveState();
 }
 
-sub runFromNow {
+sub setNextRunDateFromNow {
     my ($self, $nextRunDelay) = @_;
 
     lock($self->{nextRunDate}) if $self->{shared};
@@ -195,7 +195,7 @@ Get nextRunDate attribute as a formated string.
 
 Set next execution date.
 
-=head2 runFromNow($nextRunDelay)
+=head2 setNextRunDateFromNow($nextRunDelay)
 
 Set next execution date from now and after $nextRunDelay seconds (0 by default).
 

--- a/lib/FusionInventory/Agent/Target.pm
+++ b/lib/FusionInventory/Agent/Target.pm
@@ -66,6 +66,14 @@ sub setNextRunDate {
     $self->_saveState();
 }
 
+sub runFromNow {
+    my ($self, $nextRunDelay) = @_;
+
+    lock($self->{nextRunDate}) if $self->{shared};
+    $self->{nextRunDate} = time + ($nextRunDelay || 0);
+    $self->_saveState();
+}
+
 sub resetNextRunDate {
     my ($self) = @_;
 
@@ -186,6 +194,10 @@ Get nextRunDate attribute as a formated string.
 =head2 setNextRunDate($nextRunDate)
 
 Set next execution date.
+
+=head2 runFromNow($nextRunDelay)
+
+Set next execution date from now and after $nextRunDelay seconds (0 by default).
 
 =head2 resetNextRunDate()
 

--- a/lib/FusionInventory/Agent/Target.pm
+++ b/lib/FusionInventory/Agent/Target.pm
@@ -41,7 +41,7 @@ sub _init {
     $self->_loadState();
 
     $self->{nextRunDate} = $self->_computeNextRunDate()
-        if !$self->{nextRunDate};
+        if (!$self->{nextRunDate} || $self->{nextRunDate} < time-$self->getMaxDelay());
 
     $self->_saveState();
 


### PR DESCRIPTION
Avoid an issue where target can be retried too early on network/server error.

The issue can be triggered while inventory is forced through agent http interface.