### PR TITLE
2.3.x+fix crash on corrupted state file

### DIFF
--- a/lib/FusionInventory/Agent/Inventory.pm
+++ b/lib/FusionInventory/Agent/Inventory.pm
@@ -418,7 +418,7 @@ sub computeChecksum {
                 );
             };
             if (ref($self->{last_state_content}) ne 'HASH') {
-                $self->{last_state_file} = {};
+                $self->{last_state_content} = {};
             }
         } else {
             $logger->debug(

--- a/lib/FusionInventory/Agent/Inventory.pm
+++ b/lib/FusionInventory/Agent/Inventory.pm
@@ -13,6 +13,9 @@ use FusionInventory::Agent::Logger;
 use FusionInventory::Agent::Tools;
 use FusionInventory::Agent::Version;
 
+# Always sort keys in Dumper while computing checksum on HASH
+$Data::Dumper::Sortkeys = 1;
+
 my %fields = (
     BIOS             => [ qw/SMODEL SMANUFACTURER SSN BDATE BVERSION
                              BMANUFACTURER MMANUFACTURER MSN MMODEL ASSETTAG

--- a/lib/FusionInventory/Agent/Inventory.pm
+++ b/lib/FusionInventory/Agent/Inventory.pm
@@ -9,6 +9,7 @@ use Digest::MD5 qw(md5_base64);
 use English qw(-no_match_vars);
 use XML::TreePP;
 
+use FusionInventory::Agent::Logger;
 use FusionInventory::Agent::Tools;
 use FusionInventory::Agent::Version;
 
@@ -122,7 +123,7 @@ sub new {
     my ($class, %params) = @_;
 
     my $self = {
-        logger         => $params{logger},
+        logger         => $params{logger} || FusionInventory::Agent::Logger->new(),
         fields         => \%fields,
         content        => {
             HARDWARE => {

--- a/lib/FusionInventory/Agent/Inventory.pm
+++ b/lib/FusionInventory/Agent/Inventory.pm
@@ -456,7 +456,7 @@ sub saveLastState {
     my $logger = $self->{logger};
 
     if (!defined($self->{last_state_content})) {
-        $self->processChecksum();
+        $self->computeChecksum();
     }
     if ($self->{last_state_file}) {
         eval {


### PR DESCRIPTION
Fix crash case, wrong API call and wrong checksum-ing
Also initialize logger while not instanciated from the agent