### PR TITLE
2.3.x+linux storage update

### DIFF
--- a/lib/FusionInventory/Agent/Tools/Linux.pm
+++ b/lib/FusionInventory/Agent/Tools/Linux.pm
@@ -250,6 +250,7 @@ sub _getValueFromSysProc {
     ## no critic (ExplicitReturnUndef)
 
     my $file =
+        -f "/sys/block/$device/$key"        ? "/sys/block/$device/$key" :
         -f "/sys/block/$device/device/$key" ? "/sys/block/$device/device/$key" :
         -f "/proc/ide/$device/$key"         ? "/proc/ide/$device/$key" :
                                               undef;

--- a/lib/FusionInventory/Agent/Tools/Linux.pm
+++ b/lib/FusionInventory/Agent/Tools/Linux.pm
@@ -275,6 +275,7 @@ sub _getValueFromSysProc {
     my $value = <$handle>;
     close $handle;
 
+    return undef unless defined $value;
     $value =~ s/^(\w+)\W*/$1/;
 
     return trimWhitespace($value);

--- a/lib/FusionInventory/Agent/Tools/Linux.pm
+++ b/lib/FusionInventory/Agent/Tools/Linux.pm
@@ -252,10 +252,9 @@ sub _getValueFromSysProc {
     my $value = <$handle>;
     close $handle;
 
-    chomp $value;
     $value =~ s/^(\w+)\W*/$1/;
 
-    return $value;
+    return trimWhitespace($value);
 }
 
 sub getInfoFromSmartctl {

--- a/lib/FusionInventory/Agent/Tools/Linux.pm
+++ b/lib/FusionInventory/Agent/Tools/Linux.pm
@@ -222,7 +222,8 @@ sub getDevicesFromProc {
             NAME         => $name,
             MANUFACTURER => _getValueFromSysProc($logger, $name, 'vendor'),
             MODEL        => _getValueFromSysProc($logger, $name, 'model'),
-            FIRMWARE     => _getValueFromSysProc($logger, $name, 'rev'),
+            FIRMWARE     => _getValueFromSysProc($logger, $name, 'rev')
+                || _getValueFromSysProc($logger, $name, 'firmware_rev'),
             SERIALNUMBER => _getValueFromSysProc($logger, $name, 'serial'),
             TYPE         =>
                 _getValueFromSysProc($logger, $name, 'removable') ?

--- a/lib/FusionInventory/Agent/Tools/Linux.pm
+++ b/lib/FusionInventory/Agent/Tools/Linux.pm
@@ -187,6 +187,13 @@ sub getDevicesFromProc {
         push @names, $1;
     }
 
+    # add any block device identified as device by the kernel like SSD disks or
+    # removable disks (SD cards and others)
+    foreach my $file (glob ("/sys/block/*/device")) {
+        next unless $file =~ m|([^/]*)/device$|;
+        push @names, $1;
+    }
+
     my $command = getFirstLine(command => '/sbin/fdisk -v') =~ '^GNU' ?
         "/sbin/fdisk -p -l" :
         "/sbin/fdisk -l"    ;


### PR DESCRIPTION
Fix & update Storage inventory support for Linux
Tested:
 - PCI-based block storages are recognized (SSD disks)
 - MMC cards are recognized as removable