### PR TITLE
2.3.x+dmidecode core count support

### DIFF
--- a/lib/FusionInventory/Agent/Inventory.pm
+++ b/lib/FusionInventory/Agent/Inventory.pm
@@ -42,7 +42,7 @@ my %fields = (
                              PRODUCTID PCISUBSYSTEMID PCISLOT TYPE REV/ ],
     CPUS             => [ qw/CACHE CORE DESCRIPTION MANUFACTURER NAME THREAD
                              SERIAL STEPPING FAMILYNAME FAMILYNUMBER MODEL
-                             SPEED ID EXTERNAL_CLOCK ARCH/ ],
+                             SPEED ID EXTERNAL_CLOCK ARCH CORECOUNT/ ],
     DRIVES           => [ qw/CREATEDATE DESCRIPTION FREE FILESYSTEM LABEL
                              LETTER SERIAL SYSTEMDRIVE TOTAL TYPE VOLUMN/ ],
     ENVS             => [ qw/KEY VAL/ ],

--- a/lib/FusionInventory/Agent/Task/Inventory/Linux/i386/CPU.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Linux/i386/CPU.pm
@@ -67,10 +67,10 @@ sub _getCPUs {
             THREAD         => $thread || $dmidecodeInfo->{THREAD}
         };
 
-        $cpu->{ID}     = $dmidecodeInfo->{ID} if $dmidecodeInfo->{ID};
-        $cpu->{SERIAL} = $dmidecodeInfo->{SERIAL} if $dmidecodeInfo->{SERIAL};
-        $cpu->{EXTERNAL_CLOCK} = $dmidecodeInfo->{EXTERNAL_CLOCK} if $dmidecodeInfo->{EXTERNAL_CLOCK};
-        $cpu->{FAMILYNAME} = $dmidecodeInfo->{FAMILYNAME} if $dmidecodeInfo->{FAMILYNAME};
+        # Import some dmidecode value only when available
+        foreach my $key (qw(ID SERIAL EXTERNAL_CLOCK FAMILYNAME CORECOUNT)) {
+            $cpu->{$key} = $dmidecodeInfo->{$key} if $dmidecodeInfo->{$key};
+        }
 
         if ($cpu->{NAME} =~ /([\d\.]+)s*(GHZ)/i) {
             $cpu->{SPEED} = {

--- a/lib/FusionInventory/Agent/Task/Inventory/Win32/CPU.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Win32/CPU.pm
@@ -100,6 +100,10 @@ sub _getCPUs {
             }->{lc($2)} * $1;
         }
 
+        # Support CORECOUNT total available cores
+        $cpu->{CORECOUNT} = $dmidecodeInfo->{CORECOUNT}
+            if ($dmidecodeInfo->{CORECOUNT});
+
         push @cpus, $cpu;
 
         $cpuId++;

--- a/lib/FusionInventory/Agent/Tools/Generic.pm
+++ b/lib/FusionInventory/Agent/Tools/Generic.pm
@@ -107,7 +107,7 @@ sub getCpusFromDmidecode {
         my $cpu = {
             SERIAL       => $info->{'Serial Number'},
             ID           => $info->{ID},
-            CORE         => $info->{'Core Count'} || $info->{'Core Enabled'},
+            CORE         => $info->{'Core Enabled'} || $info->{'Core Count'},
             THREAD       => $info->{'Thread Count'},
             FAMILYNAME   => $info->{'Family'},
             MANUFACTURER => $manufacturer
@@ -151,6 +151,12 @@ sub getCpusFromDmidecode {
             } elsif ($info->{'External Clock'} =~ /^\s*(\d+)\s*Ghz/i) {
                 $cpu->{EXTERNAL_CLOCK} = $1 * 1000;
             }
+        }
+
+        # Add CORECOUNT if we have less enabled cores than total count
+        if ($info->{'Core Enabled'} && $info->{'Core Count'}) {
+            $cpu->{CORECOUNT} = $info->{'Core Count'}
+                unless ($info->{'Core Enabled'} == $info->{'Core Count'});
         }
 
         push @cpus, $cpu;

--- a/resources/generic/dmidecode/oracle-server-6.7-oda
+++ b/resources/generic/dmidecode/oracle-server-6.7-oda
@@ -1,0 +1,1492 @@
+# dmidecode 2.12
+SMBIOS 2.8 present.
+130 structures occupying 5260 bytes.
+Table at 0x000EB000.
+
+Handle 0x0000, DMI type 0, 24 bytes
+BIOS Information
+	Vendor: American Megatrends Inc.
+	Version: 30080300
+	Release Date: 05/26/2016
+	Address: 0xF0000
+	Runtime Size: 64 kB
+	ROM Size: 8192 kB
+	Characteristics:
+		PCI is supported
+		BIOS is upgradeable
+		BIOS shadowing is allowed
+		Boot from CD is supported
+		Selectable boot is supported
+		BIOS ROM is socketed
+		EDD is supported
+		5.25"/1.2 MB floppy services are supported (int 13h)
+		3.5"/720 kB floppy services are supported (int 13h)
+		3.5"/2.88 MB floppy services are supported (int 13h)
+		Print screen service is supported (int 5h)
+		8042 keyboard services are supported (int 9h)
+		Serial services are supported (int 14h)
+		Printer services are supported (int 17h)
+		ACPI is supported
+		USB legacy is supported
+		BIOS boot specification is supported
+		Targeted content distribution is supported
+		UEFI is supported
+	BIOS Revision: 8.3
+	Firmware Revision: 3.2
+
+Handle 0x0001, DMI type 1, 27 bytes
+System Information
+	Manufacturer: Oracle Corporation
+	Product Name: ORACLE SERVER X5-2
+	Version:                       
+	Serial Number: 1634NM1100
+	UUID: 080020FF-FFFF-FFFF-FFFF-0010E0BCD192
+	Wake-up Type: Power Switch
+	SKU Number: 7092459
+	Family:                       
+
+Handle 0x0002, DMI type 2, 15 bytes
+Base Board Information
+	Manufacturer: Oracle Corporation
+	Product Name: ASM,MOTHERBOARD,1U
+	Version: Rev 04
+	Serial Number: 489089M+16324B21FK
+	Asset Tag: 7317947
+	Features:
+		Board is a hosting board
+		Board is removable
+		Board is replaceable
+	Location In Chassis: /SYS/MB
+	Chassis Handle: 0x0003
+	Type: Motherboard
+	Contained Object Handles: 0
+
+Handle 0x0003, DMI type 3, 22 bytes
+Chassis Information
+	Manufacturer: Oracle Corporation
+	Type: Main Server Chassis
+	Lock: Not Present
+	Version: ORACLE SERVER X5-2
+	Serial Number: 1634NM1100
+	Asset Tag: 7092459
+	Boot-up State: Safe
+	Power Supply State: Safe
+	Thermal State: Safe
+	Security Status: None
+	OEM Information: 0x00000000
+	Height: 1 U
+	Number Of Power Cords: 2
+	Contained Elements: 0
+	SKU Number:                       
+
+Handle 0x0004, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: J2803
+	Internal Connector Type: None
+	External Reference Designator: USB Internal Connector - Bottom
+	External Connector Type: Access Bus (USB)
+	Port Type: USB
+
+Handle 0x0005, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: J2803
+	Internal Connector Type: None
+	External Reference Designator: USB Internal Connector - Top
+	External Connector Type: Access Bus (USB)
+	Port Type: USB
+
+Handle 0x0006, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: J2901
+	Internal Connector Type: None
+	External Reference Designator: VGA Connector
+	External Connector Type: DB-15 female
+	Port Type: Video Port
+
+Handle 0x0007, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: J2801
+	Internal Connector Type: None
+	External Reference Designator: USB Rear Connector - Left
+	External Connector Type: Access Bus (USB)
+	Port Type: USB
+
+Handle 0x0008, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: J2802
+	Internal Connector Type: None
+	External Reference Designator: USB Rear Connector  - Right
+	External Connector Type: Access Bus (USB)
+	Port Type: USB
+
+Handle 0x0009, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: None
+	Internal Connector Type: None
+	External Reference Designator: USB Front Connector - Left
+	External Connector Type: Access Bus (USB)
+	Port Type: USB
+
+Handle 0x000A, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: None
+	Internal Connector Type: None
+	External Reference Designator: USB Front Connector - Right
+	External Connector Type: Access Bus (USB)
+	Port Type: USB
+
+Handle 0x000B, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: J2903
+	Internal Connector Type: None
+	External Reference Designator: SER MGT
+	External Connector Type: RJ-45
+	Port Type: Serial Port 16550 Compatible
+
+Handle 0x000C, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: J2902
+	Internal Connector Type: None
+	External Reference Designator: NET MGT
+	External Connector Type: RJ-45
+	Port Type: Network Port
+
+Handle 0x000D, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: J3502
+	Internal Connector Type: None
+	External Reference Designator: NET 0
+	External Connector Type: RJ-45
+	Port Type: Network Port
+
+Handle 0x000E, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: J3501
+	Internal Connector Type: None
+	External Reference Designator: NET 1
+	External Connector Type: RJ-45
+	Port Type: Network Port
+
+Handle 0x000F, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: J3802
+	Internal Connector Type: None
+	External Reference Designator: NET 2
+	External Connector Type: RJ-45
+	Port Type: Network Port
+
+Handle 0x0010, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: J3801
+	Internal Connector Type: None
+	External Reference Designator: NET 3
+	External Connector Type: RJ-45
+	Port Type: Network Port
+
+Handle 0x0011, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: J2003
+	Internal Connector Type: None
+	External Reference Designator: DVD
+	External Connector Type: SAS/SATA Plug Receptacle
+	Port Type: SATA
+
+Handle 0x0012, DMI type 9, 17 bytes
+System Slot Information
+	Designation: /SYS/MB/RISER1/PCIE1
+	Type: x16 PCI Express 3
+	Current Usage: In Use
+	Length: Long
+	Characteristics:
+		3.3 V is provided
+		Opening is shared
+		PME signal is supported
+	Bus Address: 0000:80:03.0
+
+Handle 0x0013, DMI type 9, 17 bytes
+System Slot Information
+	Designation: /SYS/MB/RISER2/PCIE2
+	Type: x16 PCI Express 3
+	Current Usage: In Use
+	Length: Long
+	Characteristics:
+		3.3 V is provided
+		Opening is shared
+		PME signal is supported
+	Bus Address: 0000:00:02.0
+
+Handle 0x0014, DMI type 9, 17 bytes
+System Slot Information
+	Designation: /SYS/MB/RISER3/PCIE3
+	Type: x8 PCI Express 3
+	Current Usage: In Use
+	Length: Short
+	Characteristics:
+		3.3 V is provided
+		Opening is shared
+		PME signal is supported
+	Bus Address: 0000:00:01.0
+
+Handle 0x0015, DMI type 9, 17 bytes
+System Slot Information
+	Designation: /SYS/MB/RISER3/PCIE4
+	Type: x8 PCI Express 3
+	Current Usage: In Use
+	Length: Short
+	Characteristics:
+		3.3 V is provided
+		Opening is shared
+		PME signal is supported
+	Bus Address: 0000:00:03.0
+
+Handle 0x001A, DMI type 11, 5 bytes
+OEM Strings
+	String 1: SUNW-PRMS-1
+	String 2:                  
+	String 3: storage-variant:8dbp
+	String 4:                       
+	String 5:                       
+
+Handle 0x001B, DMI type 12, 5 bytes
+System Configuration Options
+	Option 1:                       
+
+Handle 0x001C, DMI type 32, 20 bytes
+System Boot Information
+	Status: No errors detected
+
+Handle 0x001D, DMI type 41, 11 bytes
+Onboard Device
+	Reference Designation:  Onboard Video
+	Type: Video
+	Status: Enabled
+	Type Instance: 1
+	Bus Address: 0000:3d:00.0
+
+Handle 0x001E, DMI type 41, 11 bytes
+Onboard Device
+	Reference Designation:  X540 10GbE Controller
+	Type: Ethernet
+	Status: Enabled
+	Type Instance: 3
+	Bus Address: 0000:82:00.0
+
+Handle 0x001F, DMI type 41, 11 bytes
+Onboard Device
+	Reference Designation:  X540 10GbE Controller
+	Type: Ethernet
+	Status: Enabled
+	Type Instance: 4
+	Bus Address: 0000:82:00.1
+
+Handle 0x0020, DMI type 41, 11 bytes
+Onboard Device
+	Reference Designation:  X540 10GbE Controller
+	Type: Ethernet
+	Status: Enabled
+	Type Instance: 1
+	Bus Address: 0000:3a:00.0
+
+Handle 0x0021, DMI type 41, 11 bytes
+Onboard Device
+	Reference Designation:  X540 10GbE Controller
+	Type: Ethernet
+	Status: Enabled
+	Type Instance: 2
+	Bus Address: 0000:3a:00.1
+
+Handle 0x0022, DMI type 129, 8 bytes
+OEM-specific Type
+	Header and Data:
+		81 08 22 00 01 02 03 04
+	Strings:
+		Oracle Corporation
+		ODA X5-2
+		34502935+1+1
+		1635NMF005
+
+Handle 0x0023, DMI type 132, 80 bytes
+OEM-specific Type
+	Header and Data:
+		84 50 23 00 60 00 01 24 00 00 01 00 02 00 03 00
+		04 00 05 00 06 00 07 00 40 00 41 00 42 00 43 00
+		44 00 45 00 46 00 47 00 47 00 47 00 47 00 47 00
+		47 00 47 00 47 00 47 00 47 00 47 00 47 00 47 00
+		47 00 47 00 47 00 47 00 47 00 47 00 47 00 47 00
+
+Handle 0x0024, DMI type 132, 80 bytes
+OEM-specific Type
+	Header and Data:
+		84 50 24 00 64 00 01 24 47 00 47 00 47 00 47 00
+		47 00 47 00 47 00 47 00 47 00 47 00 47 00 47 00
+		47 00 47 00 47 00 47 00 47 00 47 00 47 00 47 00
+		47 00 47 00 47 00 47 00 47 00 47 00 47 00 47 00
+		47 00 47 00 47 00 47 00 47 00 47 00 47 00 47 00
+
+Handle 0x0025, DMI type 138, 8 bytes
+OEM-specific Type
+	Header and Data:
+		8A 08 25 00 02 00 28 00
+
+Handle 0x0026, DMI type 138, 8 bytes
+OEM-specific Type
+	Header and Data:
+		8A 08 26 00 25 00 08 00
+
+Handle 0x0028, DMI type 138, 8 bytes
+OEM-specific Type
+	Header and Data:
+		8A 08 28 00 25 00 10 00
+
+Handle 0x002A, DMI type 138, 8 bytes
+OEM-specific Type
+	Header and Data:
+		8A 08 2A 00 25 00 18 00
+
+Handle 0x002B, DMI type 138, 8 bytes
+OEM-specific Type
+	Header and Data:
+		8A 08 2B 00 25 00 1A 00
+
+Handle 0x002C, DMI type 138, 8 bytes
+OEM-specific Type
+	Header and Data:
+		8A 08 2C 00 25 00 E7 00
+
+Handle 0x002D, DMI type 138, 8 bytes
+OEM-specific Type
+	Header and Data:
+		8A 08 2D 00 02 00 28 80
+
+Handle 0x002E, DMI type 138, 8 bytes
+OEM-specific Type
+	Header and Data:
+		8A 08 2E 00 2D 00 08 80
+
+Handle 0x0032, DMI type 138, 8 bytes
+OEM-specific Type
+	Header and Data:
+		8A 08 32 00 2D 00 18 80
+
+Handle 0x0034, DMI type 38, 18 bytes
+IPMI Device Information
+	Interface Type: KCS (Keyboard Control Style)
+	Specification Version: 2.0
+	I2C Slave Address: 0x10
+	NV Storage Device: Not Present
+	Base Address: 0x0000000000000CA2 (I/O)
+	Register Spacing: Successive Byte Boundaries
+
+Handle 0x0035, DMI type 16, 23 bytes
+Physical Memory Array
+	Location: System Board Or Motherboard
+	Use: System Memory
+	Error Correction Type: Multi-bit ECC
+	Maximum Capacity: 192 GB
+	Error Information Handle: Not Provided
+	Number Of Devices: 6
+
+Handle 0x0036, DMI type 19, 31 bytes
+Memory Array Mapped Address
+	Starting Address: 0x00000000000
+	Ending Address: 0x00FFFFFFFFF
+	Range Size: 64 GB
+	Physical Array Handle: 0x0035
+	Partition Width: 2
+
+Handle 0x0037, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x0035
+	Error Information Handle: Not Provided
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 32 GB
+	Form Factor: DIMM
+	Set: None
+	Locator: D11
+	Bank Locator: /SYS/MB/P0
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: 2133 MHz
+	Manufacturer: Samsung
+	Serial Number: 324AA44C
+	Asset Tag: DIMM_A1_AssetTag
+	Part Number: M386A4G40DM0-CPB   
+	Rank: 4
+	Configured Clock Speed: 2133 MHz
+
+Handle 0x0038, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x00000000000
+	Ending Address: 0x007FFFFFFFF
+	Range Size: 32 GB
+	Physical Device Handle: 0x0037
+	Memory Array Mapped Address Handle: 0x0036
+	Partition Row Position: 1
+
+Handle 0x0039, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x0035
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: D10
+	Bank Locator: /SYS/MB/P0
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: NO DIMM
+	Serial Number: NO DIMM
+	Asset Tag: NO DIMM
+	Part Number: NO DIMM
+	Rank: Unknown
+	Configured Clock Speed: Unknown
+
+Handle 0x003A, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x0035
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: D9
+	Bank Locator: /SYS/MB/P0
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: NO DIMM
+	Serial Number: NO DIMM
+	Asset Tag: NO DIMM
+	Part Number: NO DIMM
+	Rank: Unknown
+	Configured Clock Speed: Unknown
+
+Handle 0x003B, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x0035
+	Error Information Handle: Not Provided
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 32 GB
+	Form Factor: DIMM
+	Set: None
+	Locator: D8
+	Bank Locator: /SYS/MB/P0
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: 2133 MHz
+	Manufacturer: Samsung
+	Serial Number: 330DC609
+	Asset Tag: DIMM_B1_AssetTag
+	Part Number: M386A4G40DM0-CPB   
+	Rank: 4
+	Configured Clock Speed: 2133 MHz
+
+Handle 0x003C, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x00800000000
+	Ending Address: 0x00FFFFFFFFF
+	Range Size: 32 GB
+	Physical Device Handle: 0x003B
+	Memory Array Mapped Address Handle: 0x0036
+	Partition Row Position: 1
+
+Handle 0x003D, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x0035
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: D7
+	Bank Locator: /SYS/MB/P0
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: NO DIMM
+	Serial Number: NO DIMM
+	Asset Tag: NO DIMM
+	Part Number: NO DIMM
+	Rank: Unknown
+	Configured Clock Speed: Unknown
+
+Handle 0x003E, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x0035
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: D6
+	Bank Locator: /SYS/MB/P0
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: NO DIMM
+	Serial Number: NO DIMM
+	Asset Tag: NO DIMM
+	Part Number: NO DIMM
+	Rank: Unknown
+	Configured Clock Speed: Unknown
+
+Handle 0x003F, DMI type 16, 23 bytes
+Physical Memory Array
+	Location: System Board Or Motherboard
+	Use: System Memory
+	Error Correction Type: Multi-bit ECC
+	Maximum Capacity: 192 GB
+	Error Information Handle: Not Provided
+	Number Of Devices: 6
+
+Handle 0x0040, DMI type 19, 31 bytes
+Memory Array Mapped Address
+	Starting Address: 0x01000000000
+	Ending Address: 0x01FFFFFFFFF
+	Range Size: 64 GB
+	Physical Array Handle: 0x003F
+	Partition Width: 2
+
+Handle 0x0041, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x003F
+	Error Information Handle: Not Provided
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 32 GB
+	Form Factor: DIMM
+	Set: None
+	Locator: D0
+	Bank Locator: /SYS/MB/P0
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: 2133 MHz
+	Manufacturer: Samsung
+	Serial Number: 324AA479
+	Asset Tag: DIMM_C1_AssetTag
+	Part Number: M386A4G40DM0-CPB   
+	Rank: 4
+	Configured Clock Speed: 2133 MHz
+
+Handle 0x0042, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x01000000000
+	Ending Address: 0x017FFFFFFFF
+	Range Size: 32 GB
+	Physical Device Handle: 0x0041
+	Memory Array Mapped Address Handle: 0x0040
+	Partition Row Position: 1
+
+Handle 0x0043, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x003F
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: D1
+	Bank Locator: /SYS/MB/P0
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: NO DIMM
+	Serial Number: NO DIMM
+	Asset Tag: NO DIMM
+	Part Number: NO DIMM
+	Rank: Unknown
+	Configured Clock Speed: Unknown
+
+Handle 0x0044, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x003F
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: D2
+	Bank Locator: /SYS/MB/P0
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: NO DIMM
+	Serial Number: NO DIMM
+	Asset Tag: NO DIMM
+	Part Number: NO DIMM
+	Rank: Unknown
+	Configured Clock Speed: Unknown
+
+Handle 0x0045, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x003F
+	Error Information Handle: Not Provided
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 32 GB
+	Form Factor: DIMM
+	Set: None
+	Locator: D3
+	Bank Locator: /SYS/MB/P0
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: 2133 MHz
+	Manufacturer: Samsung
+	Serial Number: 324AA450
+	Asset Tag: DIMM_D1_AssetTag
+	Part Number: M386A4G40DM0-CPB   
+	Rank: 4
+	Configured Clock Speed: 2133 MHz
+
+Handle 0x0046, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x01800000000
+	Ending Address: 0x01FFFFFFFFF
+	Range Size: 32 GB
+	Physical Device Handle: 0x0045
+	Memory Array Mapped Address Handle: 0x0040
+	Partition Row Position: 1
+
+Handle 0x0047, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x003F
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: D4
+	Bank Locator: /SYS/MB/P0
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: NO DIMM
+	Serial Number: NO DIMM
+	Asset Tag: NO DIMM
+	Part Number: NO DIMM
+	Rank: Unknown
+	Configured Clock Speed: Unknown
+
+Handle 0x0048, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x003F
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: D5
+	Bank Locator: /SYS/MB/P0
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: NO DIMM
+	Serial Number: NO DIMM
+	Asset Tag: NO DIMM
+	Part Number: NO DIMM
+	Rank: Unknown
+	Configured Clock Speed: Unknown
+
+Handle 0x0049, DMI type 16, 23 bytes
+Physical Memory Array
+	Location: System Board Or Motherboard
+	Use: System Memory
+	Error Correction Type: Multi-bit ECC
+	Maximum Capacity: 192 GB
+	Error Information Handle: Not Provided
+	Number Of Devices: 6
+
+Handle 0x004A, DMI type 19, 31 bytes
+Memory Array Mapped Address
+	Starting Address: 0x02000000000
+	Ending Address: 0x02FFFFFFFFF
+	Range Size: 64 GB
+	Physical Array Handle: 0x0049
+	Partition Width: 2
+
+Handle 0x004B, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x0049
+	Error Information Handle: Not Provided
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 32 GB
+	Form Factor: DIMM
+	Set: None
+	Locator: D11
+	Bank Locator: /SYS/MB/P1
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: 2133 MHz
+	Manufacturer: Samsung
+	Serial Number: 324AA44B
+	Asset Tag: DIMM_E1_AssetTag
+	Part Number: M386A4G40DM0-CPB   
+	Rank: 4
+	Configured Clock Speed: 2133 MHz
+
+Handle 0x004C, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x02000000000
+	Ending Address: 0x027FFFFFFFF
+	Range Size: 32 GB
+	Physical Device Handle: 0x004B
+	Memory Array Mapped Address Handle: 0x004A
+	Partition Row Position: 1
+
+Handle 0x004D, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x0049
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: D10
+	Bank Locator: /SYS/MB/P1
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: NO DIMM
+	Serial Number: NO DIMM
+	Asset Tag: NO DIMM
+	Part Number: NO DIMM
+	Rank: Unknown
+	Configured Clock Speed: Unknown
+
+Handle 0x004E, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x0049
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: D9
+	Bank Locator: /SYS/MB/P1
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: NO DIMM
+	Serial Number: NO DIMM
+	Asset Tag: NO DIMM
+	Part Number: NO DIMM
+	Rank: Unknown
+	Configured Clock Speed: Unknown
+
+Handle 0x004F, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x0049
+	Error Information Handle: Not Provided
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 32 GB
+	Form Factor: DIMM
+	Set: None
+	Locator: D8
+	Bank Locator: /SYS/MB/P1
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: 2133 MHz
+	Manufacturer: Samsung
+	Serial Number: 330DC31B
+	Asset Tag: DIMM_F1_AssetTag
+	Part Number: M386A4G40DM0-CPB   
+	Rank: 4
+	Configured Clock Speed: 2133 MHz
+
+Handle 0x0050, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x02800000000
+	Ending Address: 0x02FFFFFFFFF
+	Range Size: 32 GB
+	Physical Device Handle: 0x004F
+	Memory Array Mapped Address Handle: 0x004A
+	Partition Row Position: 1
+
+Handle 0x0051, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x0049
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: D7
+	Bank Locator: /SYS/MB/P1
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: NO DIMM
+	Serial Number: NO DIMM
+	Asset Tag: NO DIMM
+	Part Number: NO DIMM
+	Rank: Unknown
+	Configured Clock Speed: Unknown
+
+Handle 0x0052, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x0049
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: D6
+	Bank Locator: /SYS/MB/P1
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: NO DIMM
+	Serial Number: NO DIMM
+	Asset Tag: NO DIMM
+	Part Number: NO DIMM
+	Rank: Unknown
+	Configured Clock Speed: Unknown
+
+Handle 0x0053, DMI type 16, 23 bytes
+Physical Memory Array
+	Location: System Board Or Motherboard
+	Use: System Memory
+	Error Correction Type: Multi-bit ECC
+	Maximum Capacity: 192 GB
+	Error Information Handle: Not Provided
+	Number Of Devices: 6
+
+Handle 0x0054, DMI type 19, 31 bytes
+Memory Array Mapped Address
+	Starting Address: 0x03000000000
+	Ending Address: 0x03FFFFFFFFF
+	Range Size: 64 GB
+	Physical Array Handle: 0x0053
+	Partition Width: 2
+
+Handle 0x0055, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x0053
+	Error Information Handle: Not Provided
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 32 GB
+	Form Factor: DIMM
+	Set: None
+	Locator: D0
+	Bank Locator: /SYS/MB/P1
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: 2133 MHz
+	Manufacturer: Samsung
+	Serial Number: 330DC851
+	Asset Tag: DIMM_G1_AssetTag
+	Part Number: M386A4G40DM0-CPB   
+	Rank: 4
+	Configured Clock Speed: 2133 MHz
+
+Handle 0x0056, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x03000000000
+	Ending Address: 0x037FFFFFFFF
+	Range Size: 32 GB
+	Physical Device Handle: 0x0055
+	Memory Array Mapped Address Handle: 0x0054
+	Partition Row Position: 1
+
+Handle 0x0057, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x0053
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: D1
+	Bank Locator: /SYS/MB/P1
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: NO DIMM
+	Serial Number: NO DIMM
+	Asset Tag: NO DIMM
+	Part Number: NO DIMM
+	Rank: Unknown
+	Configured Clock Speed: Unknown
+
+Handle 0x0058, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x0053
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: D2
+	Bank Locator: /SYS/MB/P1
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: NO DIMM
+	Serial Number: NO DIMM
+	Asset Tag: NO DIMM
+	Part Number: NO DIMM
+	Rank: Unknown
+	Configured Clock Speed: Unknown
+
+Handle 0x0059, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x0053
+	Error Information Handle: Not Provided
+	Total Width: 72 bits
+	Data Width: 64 bits
+	Size: 32 GB
+	Form Factor: DIMM
+	Set: None
+	Locator: D3
+	Bank Locator: /SYS/MB/P1
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: 2133 MHz
+	Manufacturer: Samsung
+	Serial Number: 324AA44A
+	Asset Tag: DIMM_H1_AssetTag
+	Part Number: M386A4G40DM0-CPB   
+	Rank: 4
+	Configured Clock Speed: 2133 MHz
+
+Handle 0x005A, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x03800000000
+	Ending Address: 0x03FFFFFFFFF
+	Range Size: 32 GB
+	Physical Device Handle: 0x0059
+	Memory Array Mapped Address Handle: 0x0054
+	Partition Row Position: 1
+
+Handle 0x005B, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x0053
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: D4
+	Bank Locator: /SYS/MB/P1
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: NO DIMM
+	Serial Number: NO DIMM
+	Asset Tag: NO DIMM
+	Part Number: NO DIMM
+	Rank: Unknown
+	Configured Clock Speed: Unknown
+
+Handle 0x005C, DMI type 17, 34 bytes
+Memory Device
+	Array Handle: 0x0053
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: D5
+	Bank Locator: /SYS/MB/P1
+	Type: DDR4
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: NO DIMM
+	Serial Number: NO DIMM
+	Asset Tag: NO DIMM
+	Part Number: NO DIMM
+	Rank: Unknown
+	Configured Clock Speed: Unknown
+
+Handle 0x005D, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: CPU Internal L1
+	Configuration: Enabled, Not Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 1152 kB
+	Maximum Size: 1152 kB
+	Supported SRAM Types:
+		Unknown
+	Installed SRAM Type: Unknown
+	Speed: Unknown
+	Error Correction Type: Parity
+	System Type: Other
+	Associativity: 8-way Set-associative
+
+Handle 0x005E, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: CPU Internal L2
+	Configuration: Enabled, Not Socketed, Level 2
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 4608 kB
+	Maximum Size: 4608 kB
+	Supported SRAM Types:
+		Unknown
+	Installed SRAM Type: Unknown
+	Speed: Unknown
+	Error Correction Type: Single-bit ECC
+	System Type: Unified
+	Associativity: 8-way Set-associative
+
+Handle 0x005F, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: CPU Internal L3
+	Configuration: Enabled, Not Socketed, Level 3
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 46080 kB
+	Maximum Size: 46080 kB
+	Supported SRAM Types:
+		Unknown
+	Installed SRAM Type: Unknown
+	Speed: Unknown
+	Error Correction Type: Single-bit ECC
+	System Type: Unified
+	Associativity: 20-way Set-associative
+
+Handle 0x0060, DMI type 4, 42 bytes
+Processor Information
+	Socket Designation: P0
+	Type: Central Processor
+	Family: Xeon
+	Manufacturer: Intel
+	ID: F2 06 03 00 FF FB EB BF
+	Signature: Type 0, Family 6, Model 63, Stepping 2
+	Flags:
+		FPU (Floating-point unit on-chip)
+		VME (Virtual mode extension)
+		DE (Debugging extension)
+		PSE (Page size extension)
+		TSC (Time stamp counter)
+		MSR (Model specific registers)
+		PAE (Physical address extension)
+		MCE (Machine check exception)
+		CX8 (CMPXCHG8 instruction supported)
+		APIC (On-chip APIC hardware supported)
+		SEP (Fast system call)
+		MTRR (Memory type range registers)
+		PGE (Page global enable)
+		MCA (Machine check architecture)
+		CMOV (Conditional move instruction supported)
+		PAT (Page attribute table)
+		PSE-36 (36-bit page size extension)
+		CLFSH (CLFLUSH instruction supported)
+		DS (Debug store)
+		ACPI (ACPI supported)
+		MMX (MMX technology supported)
+		FXSR (FXSAVE and FXSTOR instructions supported)
+		SSE (Streaming SIMD extensions)
+		SSE2 (Streaming SIMD extensions 2)
+		SS (Self-snoop)
+		HTT (Multi-threading)
+		TM (Thermal monitor supported)
+		PBE (Pending break enabled)
+	Version: Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz
+	Voltage: 1.8 V
+	External Clock: 100 MHz
+	Max Speed: 4000 MHz
+	Current Speed: 2300 MHz
+	Status: Populated, Enabled
+	Upgrade: Socket LGA2011-3
+	L1 Cache Handle: 0x005D
+	L2 Cache Handle: 0x005E
+	L3 Cache Handle: 0x005F
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: 060F    
+	Core Count: 18
+	Core Enabled: 4
+	Thread Count: 36
+	Characteristics:
+		64-bit capable
+		Multi-Core
+		Hardware Thread
+		Execute Protection
+		Enhanced Virtualization
+		Power/Performance Control
+
+Handle 0x0061, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: CPU Internal L1
+	Configuration: Enabled, Not Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 1152 kB
+	Maximum Size: 1152 kB
+	Supported SRAM Types:
+		Unknown
+	Installed SRAM Type: Unknown
+	Speed: Unknown
+	Error Correction Type: Parity
+	System Type: Other
+	Associativity: 8-way Set-associative
+
+Handle 0x0062, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: CPU Internal L2
+	Configuration: Enabled, Not Socketed, Level 2
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 4608 kB
+	Maximum Size: 4608 kB
+	Supported SRAM Types:
+		Unknown
+	Installed SRAM Type: Unknown
+	Speed: Unknown
+	Error Correction Type: Single-bit ECC
+	System Type: Unified
+	Associativity: 8-way Set-associative
+
+Handle 0x0063, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: CPU Internal L3
+	Configuration: Enabled, Not Socketed, Level 3
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 46080 kB
+	Maximum Size: 46080 kB
+	Supported SRAM Types:
+		Unknown
+	Installed SRAM Type: Unknown
+	Speed: Unknown
+	Error Correction Type: Single-bit ECC
+	System Type: Unified
+	Associativity: 20-way Set-associative
+
+Handle 0x0064, DMI type 4, 42 bytes
+Processor Information
+	Socket Designation: P1
+	Type: Central Processor
+	Family: Xeon
+	Manufacturer: Intel
+	ID: F2 06 03 00 FF FB EB BF
+	Signature: Type 0, Family 6, Model 63, Stepping 2
+	Flags:
+		FPU (Floating-point unit on-chip)
+		VME (Virtual mode extension)
+		DE (Debugging extension)
+		PSE (Page size extension)
+		TSC (Time stamp counter)
+		MSR (Model specific registers)
+		PAE (Physical address extension)
+		MCE (Machine check exception)
+		CX8 (CMPXCHG8 instruction supported)
+		APIC (On-chip APIC hardware supported)
+		SEP (Fast system call)
+		MTRR (Memory type range registers)
+		PGE (Page global enable)
+		MCA (Machine check architecture)
+		CMOV (Conditional move instruction supported)
+		PAT (Page attribute table)
+		PSE-36 (36-bit page size extension)
+		CLFSH (CLFLUSH instruction supported)
+		DS (Debug store)
+		ACPI (ACPI supported)
+		MMX (MMX technology supported)
+		FXSR (FXSAVE and FXSTOR instructions supported)
+		SSE (Streaming SIMD extensions)
+		SSE2 (Streaming SIMD extensions 2)
+		SS (Self-snoop)
+		HTT (Multi-threading)
+		TM (Thermal monitor supported)
+		PBE (Pending break enabled)
+	Version: Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz
+	Voltage: 1.8 V
+	External Clock: 100 MHz
+	Max Speed: 4000 MHz
+	Current Speed: 2300 MHz
+	Status: Populated, Enabled
+	Upgrade: Socket LGA2011-3
+	L1 Cache Handle: 0x0061
+	L2 Cache Handle: 0x0062
+	L3 Cache Handle: 0x0063
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: 060F    
+	Core Count: 18
+	Core Enabled: 4
+	Thread Count: 36
+	Characteristics:
+		64-bit capable
+		Multi-Core
+		Hardware Thread
+		Execute Protection
+		Enhanced Virtualization
+		Power/Performance Control
+
+Handle 0x0065, DMI type 13, 22 bytes
+BIOS Language Information
+	Language Description Format: Long
+	Installable Languages: 1
+		en|US|iso8859-1
+	Currently Installed Language: en|US|iso8859-1
+
+Handle 0x0066, DMI type 37, 16 bytes
+Memory Channel
+	Type: RamBus
+	Maximal Load: 8
+	Devices: 3
+	Device 1 Load: 0
+	Device 1 Handle: 0x0039
+	Device 2 Load: 0
+	Device 2 Handle: 0x003A
+	Device 3 Load: 0
+	Device 3 Handle: 0x2500
+
+Handle 0x0067, DMI type 37, 16 bytes
+Memory Channel
+	Type: RamBus
+	Maximal Load: 8
+	Devices: 3
+	Device 1 Load: 0
+	Device 1 Handle: 0x003D
+	Device 2 Load: 0
+	Device 2 Handle: 0x003E
+	Device 3 Load: 0
+	Device 3 Handle: 0x2500
+
+Handle 0x0068, DMI type 37, 16 bytes
+Memory Channel
+	Type: RamBus
+	Maximal Load: 8
+	Devices: 3
+	Device 1 Load: 0
+	Device 1 Handle: 0x0043
+	Device 2 Load: 0
+	Device 2 Handle: 0x0044
+	Device 3 Load: 0
+	Device 3 Handle: 0x2500
+
+Handle 0x0069, DMI type 37, 16 bytes
+Memory Channel
+	Type: RamBus
+	Maximal Load: 8
+	Devices: 3
+	Device 1 Load: 0
+	Device 1 Handle: 0x0047
+	Device 2 Load: 0
+	Device 2 Handle: 0x0048
+	Device 3 Load: 0
+	Device 3 Handle: 0x2500
+
+Handle 0x006A, DMI type 37, 16 bytes
+Memory Channel
+	Type: RamBus
+	Maximal Load: 8
+	Devices: 3
+	Device 1 Load: 0
+	Device 1 Handle: 0x004D
+	Device 2 Load: 0
+	Device 2 Handle: 0x004E
+	Device 3 Load: 0
+	Device 3 Handle: 0x2500
+
+Handle 0x006B, DMI type 37, 16 bytes
+Memory Channel
+	Type: RamBus
+	Maximal Load: 8
+	Devices: 3
+	Device 1 Load: 0
+	Device 1 Handle: 0x0051
+	Device 2 Load: 0
+	Device 2 Handle: 0x0052
+	Device 3 Load: 0
+	Device 3 Handle: 0x2500
+
+Handle 0x006C, DMI type 37, 16 bytes
+Memory Channel
+	Type: RamBus
+	Maximal Load: 8
+	Devices: 3
+	Device 1 Load: 0
+	Device 1 Handle: 0x0057
+	Device 2 Load: 0
+	Device 2 Handle: 0x0058
+	Device 3 Load: 0
+	Device 3 Handle: 0x2500
+
+Handle 0x006D, DMI type 37, 16 bytes
+Memory Channel
+	Type: RamBus
+	Maximal Load: 8
+	Devices: 3
+	Device 1 Load: 0
+	Device 1 Handle: 0x005B
+	Device 2 Load: 0
+	Device 2 Handle: 0x005C
+	Device 3 Load: 0
+	Device 3 Handle: 0x9000
+
+Handle 0x006E, DMI type 144, 10 bytes
+OEM-specific Type
+	Header and Data:
+		90 0A 6E 00 35 00 60 00 98 7F
+
+Handle 0x006F, DMI type 144, 10 bytes
+OEM-specific Type
+	Header and Data:
+		90 0A 6F 00 3F 00 60 00 B0 7F
+
+Handle 0x0070, DMI type 144, 10 bytes
+OEM-specific Type
+	Header and Data:
+		90 0A 70 00 49 00 64 00 98 FF
+
+Handle 0x0071, DMI type 144, 10 bytes
+OEM-specific Type
+	Header and Data:
+		90 0A 71 00 53 00 64 00 B0 FF
+
+Handle 0x0072, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 72 00 37 00 00 01 00
+
+Handle 0x0073, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 73 00 39 00 00 01 00
+
+Handle 0x0074, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 74 00 3A 00 00 01 00
+
+Handle 0x0075, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 75 00 3B 00 01 01 00
+
+Handle 0x0076, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 76 00 3D 00 01 01 00
+
+Handle 0x0077, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 77 00 3E 00 01 01 00
+
+Handle 0x0078, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 78 00 41 00 00 01 00
+
+Handle 0x0079, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 79 00 43 00 00 01 00
+
+Handle 0x007A, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 7A 00 44 00 00 01 00
+
+Handle 0x007B, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 7B 00 45 00 01 01 00
+
+Handle 0x007C, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 7C 00 47 00 01 01 00
+
+Handle 0x007D, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 7D 00 48 00 01 01 00
+
+Handle 0x007E, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 7E 00 4B 00 00 01 00
+
+Handle 0x007F, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 7F 00 4D 00 00 01 00
+
+Handle 0x0080, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 80 00 4E 00 00 01 00
+
+Handle 0x0081, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 81 00 4F 00 01 01 00
+
+Handle 0x0082, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 82 00 51 00 01 01 00
+
+Handle 0x0083, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 83 00 52 00 01 01 00
+
+Handle 0x0084, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 84 00 55 00 00 01 00
+
+Handle 0x0085, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 85 00 57 00 00 01 00
+
+Handle 0x0086, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 86 00 58 00 00 01 00
+
+Handle 0x0087, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 87 00 59 00 01 01 00
+
+Handle 0x0088, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 88 00 5B 00 01 01 00
+
+Handle 0x0089, DMI type 145, 9 bytes
+OEM-specific Type
+	Header and Data:
+		91 09 89 00 5C 00 01 01 00
+
+Handle 0x008A, DMI type 192, 21 bytes
+OEM-specific Type
+	Header and Data:
+		C0 15 8A 00 00 01 00 00 00 00 00 00 00 01 00 00
+		00 00 00 00 00
+
+Handle 0x008B, DMI type 127, 4 bytes
+End Of Table

--- a/resources/generic/dmidecode/rhel-6.2-vmware-2vcpus
+++ b/resources/generic/dmidecode/rhel-6.2-vmware-2vcpus
@@ -1,0 +1,6042 @@
+# dmidecode 2.11
+SMBIOS 2.4 present.
+364 structures occupying 17030 bytes.
+Table at 0x000E0010.
+
+Handle 0x0000, DMI type 0, 24 bytes
+BIOS Information
+	Vendor: Phoenix Technologies LTD
+	Version: 6.00
+	Release Date: 07/30/2013
+	Address: 0xEA050
+	Runtime Size: 90032 bytes
+	ROM Size: 64 kB
+	Characteristics:
+		ISA is supported
+		PCI is supported
+		PC Card (PCMCIA) is supported
+		PNP is supported
+		APM is supported
+		BIOS is upgradeable
+		BIOS shadowing is allowed
+		ESCD support is available
+		Boot from CD is supported
+		Selectable boot is supported
+		EDD is supported
+		Print screen service is supported (int 5h)
+		8042 keyboard services are supported (int 9h)
+		Serial services are supported (int 14h)
+		Printer services are supported (int 17h)
+		CGA/mono video services are supported (int 10h)
+		ACPI is supported
+		Smart battery is supported
+		BIOS boot specification is supported
+		Function key-initiated network boot is supported
+		Targeted content distribution is supported
+	BIOS Revision: 4.6
+	Firmware Revision: 0.0
+
+Handle 0x0001, DMI type 1, 27 bytes
+System Information
+	Manufacturer: VMware, Inc.
+	Product Name: VMware Virtual Platform
+	Version: None
+	Serial Number: VMware-42 1b ba bd 5f 4e af 7e-3a 56 b5 af 1c e1 a9 77
+	UUID: 421BBABD-5F4E-AF7E-3A56-B5AF1CE1A977
+	Wake-up Type: Power Switch
+	SKU Number: Not Specified
+	Family: Not Specified
+
+Handle 0x0002, DMI type 2, 15 bytes
+Base Board Information
+	Manufacturer: Intel Corporation
+	Product Name: 440BX Desktop Reference Platform
+	Version: None
+	Serial Number: None
+	Asset Tag: Not Specified
+	Features: None
+	Location In Chassis: Not Specified
+	Chassis Handle: 0x0000
+	Type: Unknown
+	Contained Object Handles: 0
+
+Handle 0x0003, DMI type 3, 21 bytes
+Chassis Information
+	Manufacturer: No Enclosure
+	Type: Other
+	Lock: Not Present
+	Version: N/A
+	Serial Number: None
+	Asset Tag: No Asset Tag
+	Boot-up State: Safe
+	Power Supply State: Safe
+	Thermal State: Safe
+	Security Status: None
+	OEM Information: 0x00001234
+	Height: Unspecified
+	Number Of Power Cords: Unspecified
+	Contained Elements: 0
+
+Handle 0x0004, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #0
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 01 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Enabled
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0054
+	L2 Cache Handle: 0x0055
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0005, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #1
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Enabled
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0056
+	L2 Cache Handle: 0x0057
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0006, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #2
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0058
+	L2 Cache Handle: 0x0059
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0007, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #3
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x005A
+	L2 Cache Handle: 0x005B
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0008, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #4
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x005C
+	L2 Cache Handle: 0x005D
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0009, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #5
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x005E
+	L2 Cache Handle: 0x005F
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x000A, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #6
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0060
+	L2 Cache Handle: 0x0061
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x000B, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #7
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0062
+	L2 Cache Handle: 0x0063
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x000C, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #8
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0064
+	L2 Cache Handle: 0x0065
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x000D, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #9
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0066
+	L2 Cache Handle: 0x0067
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x000E, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #10
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0068
+	L2 Cache Handle: 0x0069
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x000F, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #11
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x006A
+	L2 Cache Handle: 0x006B
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0010, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #12
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x006C
+	L2 Cache Handle: 0x006D
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0011, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #13
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x006E
+	L2 Cache Handle: 0x006F
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0012, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #14
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0070
+	L2 Cache Handle: 0x0071
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0013, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #15
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0072
+	L2 Cache Handle: 0x0073
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0014, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #16
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0074
+	L2 Cache Handle: 0x0075
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0015, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #17
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0076
+	L2 Cache Handle: 0x0077
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0016, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #18
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0078
+	L2 Cache Handle: 0x0079
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0017, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #19
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x007A
+	L2 Cache Handle: 0x007B
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0018, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #20
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x007C
+	L2 Cache Handle: 0x007D
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0019, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #21
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x007E
+	L2 Cache Handle: 0x007F
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x001A, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #22
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0080
+	L2 Cache Handle: 0x0081
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x001B, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #23
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0082
+	L2 Cache Handle: 0x0083
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x001C, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #24
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0084
+	L2 Cache Handle: 0x0085
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x001D, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #25
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0086
+	L2 Cache Handle: 0x0087
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x001E, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #26
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0088
+	L2 Cache Handle: 0x0089
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x001F, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #27
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x008A
+	L2 Cache Handle: 0x008B
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0020, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #28
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x008C
+	L2 Cache Handle: 0x008D
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0021, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #29
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x008E
+	L2 Cache Handle: 0x008F
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0022, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #30
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0090
+	L2 Cache Handle: 0x0091
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0023, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #31
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0092
+	L2 Cache Handle: 0x0093
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0024, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #32
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0094
+	L2 Cache Handle: 0x0095
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0025, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #33
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0096
+	L2 Cache Handle: 0x0097
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0026, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #34
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x0098
+	L2 Cache Handle: 0x0099
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0027, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #35
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x009A
+	L2 Cache Handle: 0x009B
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0028, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #36
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x009C
+	L2 Cache Handle: 0x009D
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0029, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #37
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x009E
+	L2 Cache Handle: 0x009F
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x002A, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #38
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00A0
+	L2 Cache Handle: 0x00A1
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x002B, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #39
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00A2
+	L2 Cache Handle: 0x00A3
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x002C, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #40
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00A4
+	L2 Cache Handle: 0x00A5
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x002D, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #41
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00A6
+	L2 Cache Handle: 0x00A7
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x002E, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #42
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00A8
+	L2 Cache Handle: 0x00A9
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x002F, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #43
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00AA
+	L2 Cache Handle: 0x00AB
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0030, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #44
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00AC
+	L2 Cache Handle: 0x00AD
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0031, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #45
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00AE
+	L2 Cache Handle: 0x00AF
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0032, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #46
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00B0
+	L2 Cache Handle: 0x00B1
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0033, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #47
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00B2
+	L2 Cache Handle: 0x00B3
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0034, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #48
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00B4
+	L2 Cache Handle: 0x00B5
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0035, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #49
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00B6
+	L2 Cache Handle: 0x00B7
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0036, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #50
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00B8
+	L2 Cache Handle: 0x00B9
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0037, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #51
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00BA
+	L2 Cache Handle: 0x00BB
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0038, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #52
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00BC
+	L2 Cache Handle: 0x00BD
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0039, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #53
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00BE
+	L2 Cache Handle: 0x00BF
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x003A, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #54
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00C0
+	L2 Cache Handle: 0x00C1
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x003B, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #55
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00C2
+	L2 Cache Handle: 0x00C3
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x003C, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #56
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00C4
+	L2 Cache Handle: 0x00C5
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x003D, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #57
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00C6
+	L2 Cache Handle: 0x00C7
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x003E, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #58
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00C8
+	L2 Cache Handle: 0x00C9
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x003F, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #59
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00CA
+	L2 Cache Handle: 0x00CB
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0040, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #60
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00CC
+	L2 Cache Handle: 0x00CD
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0041, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #61
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00CE
+	L2 Cache Handle: 0x00CF
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0042, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #62
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00D0
+	L2 Cache Handle: 0x00D1
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0043, DMI type 4, 35 bytes
+Processor Information
+	Socket Designation: CPU socket #63
+	Type: Central Processor
+	Family: Unknown
+	Manufacturer: GenuineIntel
+	ID: A4 06 00 00 FF FB AB 0F
+	Version: Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+	Voltage: 3.3 V
+	External Clock: Unknown
+	Max Speed: 30000 MHz
+	Current Speed: 1867 MHz
+	Status: Populated, Disabled By BIOS
+	Upgrade: ZIF Socket
+	L1 Cache Handle: 0x00D2
+	L2 Cache Handle: 0x00D3
+	L3 Cache Handle: Not Provided
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0044, DMI type 5, 46 bytes
+Memory Controller Information
+	Error Detecting Method: None
+	Error Correcting Capabilities:
+		None
+	Supported Interleave: One-way Interleave
+	Current Interleave: One-way Interleave
+	Maximum Memory Module Size: 32768 MB
+	Maximum Total Memory Size: 491520 MB
+	Supported Speeds:
+		70 ns
+		60 ns
+	Supported Memory Types:
+		FPM
+		EDO
+		DIMM
+		SDRAM
+	Memory Module Voltage: 3.3 V
+	Associated Memory Slots: 15
+		0x0045
+		0x0046
+		0x0047
+		0x0048
+		0x0049
+		0x004A
+		0x004B
+		0x004C
+		0x004D
+		0x004E
+		0x004F
+		0x0050
+		0x0051
+		0x0052
+		0x0053
+	Enabled Error Correcting Capabilities:
+		None
+
+Handle 0x0045, DMI type 6, 12 bytes
+Memory Module Information
+	Socket Designation: RAM socket #0
+	Bank Connections: None
+	Current Speed: Unknown
+	Type: EDO DIMM
+	Installed Size: 4096 MB (Single-bank Connection)
+	Enabled Size: 4096 MB (Single-bank Connection)
+	Error Status: OK
+
+Handle 0x0046, DMI type 6, 12 bytes
+Memory Module Information
+	Socket Designation: RAM socket #1
+	Bank Connections: None
+	Current Speed: Unknown
+	Type: DIMM
+	Installed Size: Not Installed
+	Enabled Size: Not Installed
+	Error Status: OK
+
+Handle 0x0047, DMI type 6, 12 bytes
+Memory Module Information
+	Socket Designation: RAM socket #2
+	Bank Connections: None
+	Current Speed: Unknown
+	Type: DIMM
+	Installed Size: Not Installed
+	Enabled Size: Not Installed
+	Error Status: OK
+
+Handle 0x0048, DMI type 6, 12 bytes
+Memory Module Information
+	Socket Designation: RAM socket #3
+	Bank Connections: None
+	Current Speed: Unknown
+	Type: DIMM
+	Installed Size: Not Installed
+	Enabled Size: Not Installed
+	Error Status: OK
+
+Handle 0x0049, DMI type 6, 12 bytes
+Memory Module Information
+	Socket Designation: RAM socket #4
+	Bank Connections: None
+	Current Speed: Unknown
+	Type: DIMM
+	Installed Size: Not Installed
+	Enabled Size: Not Installed
+	Error Status: OK
+
+Handle 0x004A, DMI type 6, 12 bytes
+Memory Module Information
+	Socket Designation: RAM socket #5
+	Bank Connections: None
+	Current Speed: Unknown
+	Type: DIMM
+	Installed Size: Not Installed
+	Enabled Size: Not Installed
+	Error Status: OK
+
+Handle 0x004B, DMI type 6, 12 bytes
+Memory Module Information
+	Socket Designation: RAM socket #6
+	Bank Connections: None
+	Current Speed: Unknown
+	Type: DIMM
+	Installed Size: Not Installed
+	Enabled Size: Not Installed
+	Error Status: OK
+
+Handle 0x004C, DMI type 6, 12 bytes
+Memory Module Information
+	Socket Designation: RAM socket #7
+	Bank Connections: None
+	Current Speed: Unknown
+	Type: DIMM
+	Installed Size: Not Installed
+	Enabled Size: Not Installed
+	Error Status: OK
+
+Handle 0x004D, DMI type 6, 12 bytes
+Memory Module Information
+	Socket Designation: RAM socket #8
+	Bank Connections: None
+	Current Speed: Unknown
+	Type: DIMM
+	Installed Size: Not Installed
+	Enabled Size: Not Installed
+	Error Status: OK
+
+Handle 0x004E, DMI type 6, 12 bytes
+Memory Module Information
+	Socket Designation: RAM socket #9
+	Bank Connections: None
+	Current Speed: Unknown
+	Type: DIMM
+	Installed Size: Not Installed
+	Enabled Size: Not Installed
+	Error Status: OK
+
+Handle 0x004F, DMI type 6, 12 bytes
+Memory Module Information
+	Socket Designation: RAM socket #10
+	Bank Connections: None
+	Current Speed: Unknown
+	Type: DIMM
+	Installed Size: Not Installed
+	Enabled Size: Not Installed
+	Error Status: OK
+
+Handle 0x0050, DMI type 6, 12 bytes
+Memory Module Information
+	Socket Designation: RAM socket #11
+	Bank Connections: None
+	Current Speed: Unknown
+	Type: DIMM
+	Installed Size: Not Installed
+	Enabled Size: Not Installed
+	Error Status: OK
+
+Handle 0x0051, DMI type 6, 12 bytes
+Memory Module Information
+	Socket Designation: RAM socket #12
+	Bank Connections: None
+	Current Speed: Unknown
+	Type: DIMM
+	Installed Size: Not Installed
+	Enabled Size: Not Installed
+	Error Status: OK
+
+Handle 0x0052, DMI type 6, 12 bytes
+Memory Module Information
+	Socket Designation: RAM socket #13
+	Bank Connections: None
+	Current Speed: Unknown
+	Type: DIMM
+	Installed Size: Not Installed
+	Enabled Size: Not Installed
+	Error Status: OK
+
+Handle 0x0053, DMI type 6, 12 bytes
+Memory Module Information
+	Socket Designation: RAM socket #14
+	Bank Connections: None
+	Current Speed: Unknown
+	Type: DIMM
+	Installed Size: Not Installed
+	Enabled Size: Not Installed
+	Error Status: OK
+
+Handle 0x0054, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0055, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0056, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0057, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0058, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0059, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x005A, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x005B, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x005C, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x005D, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x005E, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x005F, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0060, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0061, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0062, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0063, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0064, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0065, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0066, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0067, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0068, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0069, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x006A, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x006B, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x006C, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x006D, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x006E, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x006F, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0070, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0071, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0072, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0073, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0074, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0075, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0076, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0077, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0078, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0079, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x007A, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x007B, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x007C, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x007D, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x007E, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x007F, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0080, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0081, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0082, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0083, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0084, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0085, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0086, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0087, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0088, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0089, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x008A, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x008B, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x008C, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x008D, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x008E, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x008F, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0090, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0091, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0092, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0093, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0094, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0095, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0096, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0097, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0098, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x0099, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x009A, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x009B, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x009C, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x009D, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x009E, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x009F, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00A0, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00A1, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00A2, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00A3, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00A4, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00A5, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00A6, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00A7, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00A8, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00A9, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00AA, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00AB, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00AC, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00AD, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00AE, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00AF, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00B0, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00B1, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00B2, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00B3, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00B4, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00B5, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00B6, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00B7, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00B8, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00B9, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00BA, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00BB, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00BC, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00BD, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00BE, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00BF, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00C0, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00C1, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00C2, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00C3, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00C4, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00C5, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00C6, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00C7, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00C8, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00C9, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00CA, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00CB, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00CC, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00CD, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00CE, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00CF, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00D0, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00D1, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00D2, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 16 kB
+	Maximum Size: 16 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Asynchronous
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00D3, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Socketed, Level 2
+	Operational Mode: Write Back
+	Location: External
+	Installed Size: 256 kB
+	Maximum Size: 24576 kB
+	Supported SRAM Types:
+		Burst
+		Pipeline Burst
+		Asynchronous
+	Installed SRAM Type: Burst
+	Speed: Unknown
+	Error Correction Type: Unknown
+	System Type: Unknown
+	Associativity: Unknown
+
+Handle 0x00D4, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: J19
+	Internal Connector Type: 9 Pin Dual Inline (pin 10 cut)
+	External Reference Designator: COM 1
+	External Connector Type: DB-9 male
+	Port Type: Serial Port 16550A Compatible
+
+Handle 0x00D5, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: J23
+	Internal Connector Type: 25 Pin Dual Inline (pin 26 cut)
+	External Reference Designator: Parallel
+	External Connector Type: DB-25 female
+	Port Type: Parallel Port ECP/EPP
+
+Handle 0x00D6, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: J11
+	Internal Connector Type: None
+	External Reference Designator: Keyboard
+	External Connector Type: Circular DIN-8 male
+	Port Type: Keyboard Port
+
+Handle 0x00D7, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: J12
+	Internal Connector Type: None
+	External Reference Designator: PS/2 Mouse
+	External Connector Type: Circular DIN-8 male
+	Port Type: Keyboard Port
+
+Handle 0x00D8, DMI type 9, 13 bytes
+System Slot Information
+	Designation: ISA Slot J8
+	Type: 16-bit ISA
+	Current Usage: Unknown
+	Length: Short
+	Characteristics:
+		5.0 V is provided
+
+Handle 0x00D9, DMI type 9, 13 bytes
+System Slot Information
+	Designation: ISA Slot J9
+	Type: 16-bit ISA
+	Current Usage: Unknown
+	Length: Short
+	Characteristics:
+		5.0 V is provided
+
+Handle 0x00DA, DMI type 9, 13 bytes
+System Slot Information
+	Designation: ISA Slot J10
+	Type: 16-bit ISA
+	Current Usage: Unknown
+	Length: Short
+	Characteristics:
+		5.0 V is provided
+
+Handle 0x00DB, DMI type 9, 13 bytes
+System Slot Information
+	Designation: PCI Slot J11
+	Type: 32-bit PCI
+	Current Usage: In Use
+	Length: Long
+	ID: 1
+	Characteristics:
+		5.0 V is provided
+		3.3 V is provided
+
+Handle 0x00DC, DMI type 9, 13 bytes
+System Slot Information
+	Designation: PCI Slot J12
+	Type: 32-bit PCI
+	Current Usage: Available
+	Length: Long
+	ID: 2
+	Characteristics:
+		5.0 V is provided
+		3.3 V is provided
+
+Handle 0x00DD, DMI type 9, 13 bytes
+System Slot Information
+	Designation: PCI Slot J13
+	Type: 32-bit PCI
+	Current Usage: In Use
+	Length: Long
+	ID: 3
+	Characteristics:
+		5.0 V is provided
+		3.3 V is provided
+
+Handle 0x00DE, DMI type 9, 13 bytes
+System Slot Information
+	Designation: PCI Slot J14
+	Type: 32-bit PCI
+	Current Usage: Available
+	Length: Long
+	ID: 4
+	Characteristics:
+		5.0 V is provided
+		3.3 V is provided
+
+Handle 0x00DF, DMI type 10, 8 bytes
+On Board Device 1 Information
+	Type: Video
+	Status: Disabled
+	Description: VMware SVGA II
+On Board Device 2 Information
+	Type: Sound
+	Status: Disabled
+	Description: ES1371
+
+Handle 0x00E0, DMI type 11, 5 bytes
+OEM Strings
+	String 1: [MS_VM_CERT/SHA1/27d66596a61c48dd3dc7216fd715126e33f59ae7]
+	String 2: Welcome to the Virtual Machine
+
+Handle 0x00E1, DMI type 15, 29 bytes
+System Event Log
+	Area Length: 16 bytes
+	Header Start Offset: 0x0000
+	Header Length: 16 bytes
+	Data Start Offset: 0x0010
+	Access Method: General-purpose non-volatile data functions
+	Access Address: 0x0000
+	Status: Invalid, Full
+	Change Token: 0x00000036
+	Header Format: Type 1
+	Supported Log Type Descriptors: 3
+	Descriptor 1: POST error
+	Data Format 1: POST results bitmap
+	Descriptor 2: Single-bit ECC memory error
+	Data Format 2: Multiple-event
+	Descriptor 3: Multi-bit ECC memory error
+	Data Format 3: Multiple-event
+
+Handle 0x00E2, DMI type 16, 15 bytes
+Physical Memory Array
+	Location: System Board Or Motherboard
+	Use: System Memory
+	Error Correction Type: None
+	Maximum Capacity: 1 TB
+	Error Information Handle: Not Provided
+	Number Of Devices: 64
+
+Handle 0x00E3, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: 32 bits
+	Data Width: 32 bits
+	Size: 4096 MB
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #0
+	Bank Locator: RAM slot #0
+	Type: DRAM
+	Type Detail: EDO
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00E4, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #1
+	Bank Locator: RAM slot #1
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00E5, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #2
+	Bank Locator: RAM slot #2
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00E6, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #3
+	Bank Locator: RAM slot #3
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00E7, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #4
+	Bank Locator: RAM slot #4
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00E8, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #5
+	Bank Locator: RAM slot #5
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00E9, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #6
+	Bank Locator: RAM slot #6
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00EA, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #7
+	Bank Locator: RAM slot #7
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00EB, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #8
+	Bank Locator: RAM slot #8
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00EC, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #9
+	Bank Locator: RAM slot #9
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00ED, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #10
+	Bank Locator: RAM slot #10
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00EE, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #11
+	Bank Locator: RAM slot #11
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00EF, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #12
+	Bank Locator: RAM slot #12
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00F0, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #13
+	Bank Locator: RAM slot #13
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00F1, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #14
+	Bank Locator: RAM slot #14
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00F2, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #15
+	Bank Locator: RAM slot #15
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00F3, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #16
+	Bank Locator: RAM slot #16
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00F4, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #17
+	Bank Locator: RAM slot #17
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00F5, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #18
+	Bank Locator: RAM slot #18
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00F6, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #19
+	Bank Locator: RAM slot #19
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00F7, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #20
+	Bank Locator: RAM slot #20
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00F8, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #21
+	Bank Locator: RAM slot #21
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00F9, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #22
+	Bank Locator: RAM slot #22
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00FA, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #23
+	Bank Locator: RAM slot #23
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00FB, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #24
+	Bank Locator: RAM slot #24
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00FC, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #25
+	Bank Locator: RAM slot #25
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00FD, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #26
+	Bank Locator: RAM slot #26
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00FE, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #27
+	Bank Locator: RAM slot #27
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x00FF, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #28
+	Bank Locator: RAM slot #28
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0100, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #29
+	Bank Locator: RAM slot #29
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0101, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #30
+	Bank Locator: RAM slot #30
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0102, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #31
+	Bank Locator: RAM slot #31
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0103, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #32
+	Bank Locator: RAM slot #32
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0104, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #33
+	Bank Locator: RAM slot #33
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0105, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #34
+	Bank Locator: RAM slot #34
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0106, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #35
+	Bank Locator: RAM slot #35
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0107, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #36
+	Bank Locator: RAM slot #36
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0108, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #37
+	Bank Locator: RAM slot #37
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0109, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #38
+	Bank Locator: RAM slot #38
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x010A, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #39
+	Bank Locator: RAM slot #39
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x010B, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #40
+	Bank Locator: RAM slot #40
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x010C, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #41
+	Bank Locator: RAM slot #41
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x010D, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #42
+	Bank Locator: RAM slot #42
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x010E, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #43
+	Bank Locator: RAM slot #43
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x010F, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #44
+	Bank Locator: RAM slot #44
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0110, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #45
+	Bank Locator: RAM slot #45
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0111, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #46
+	Bank Locator: RAM slot #46
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0112, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #47
+	Bank Locator: RAM slot #47
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0113, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #48
+	Bank Locator: RAM slot #48
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0114, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #49
+	Bank Locator: RAM slot #49
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0115, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #50
+	Bank Locator: RAM slot #50
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0116, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #51
+	Bank Locator: RAM slot #51
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0117, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #52
+	Bank Locator: RAM slot #52
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0118, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #53
+	Bank Locator: RAM slot #53
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0119, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #54
+	Bank Locator: RAM slot #54
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x011A, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #55
+	Bank Locator: RAM slot #55
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x011B, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #56
+	Bank Locator: RAM slot #56
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x011C, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #57
+	Bank Locator: RAM slot #57
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x011D, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #58
+	Bank Locator: RAM slot #58
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x011E, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #59
+	Bank Locator: RAM slot #59
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x011F, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #60
+	Bank Locator: RAM slot #60
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0120, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #61
+	Bank Locator: RAM slot #61
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0121, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #62
+	Bank Locator: RAM slot #62
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0122, DMI type 17, 27 bytes
+Memory Device
+	Array Handle: 0x00E2
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: None
+	Locator: RAM slot #63
+	Bank Locator: RAM slot #63
+	Type: DRAM
+	Type Detail: Unknown
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+
+Handle 0x0123, DMI type 18, 23 bytes
+32-bit Memory Error Information
+	Type: OK
+	Granularity: Unknown
+	Operation: Unknown
+	Vendor Syndrome: Unknown
+	Memory Array Address: Unknown
+	Device Address: Unknown
+	Resolution: Unknown
+
+Handle 0x0124, DMI type 19, 15 bytes
+Memory Array Mapped Address
+	Starting Address: 0x00000000000
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 4 GB
+	Physical Array Handle: 0x00E2
+	Partition Width: 64
+
+Handle 0x0125, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x00000000000
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 4 GB
+	Physical Device Handle: 0x00E3
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0126, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00E4
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0127, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00E5
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0128, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00E6
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0129, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00E7
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x012A, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00E8
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x012B, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00E9
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x012C, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00EA
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x012D, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00EB
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x012E, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00EC
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x012F, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00ED
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0130, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00EE
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0131, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00EF
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0132, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00F0
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0133, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00F1
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0134, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00F2
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0135, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00F3
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0136, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00F4
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0137, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00F5
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0138, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00F6
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0139, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00F7
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x013A, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00F8
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x013B, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00F9
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x013C, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00FA
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x013D, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00FB
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x013E, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00FC
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x013F, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00FD
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0140, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00FE
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0141, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x00FF
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0142, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0100
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0143, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0101
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0144, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0102
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0145, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0103
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0146, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0104
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0147, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0105
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0148, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0106
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0149, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0107
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x014A, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0108
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x014B, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0109
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x014C, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x010A
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x014D, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x010B
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x014E, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x010C
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x014F, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x010D
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0150, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x010E
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0151, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x010F
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0152, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0110
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0153, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0111
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0154, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0112
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0155, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0113
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0156, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0114
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0157, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0115
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0158, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0116
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0159, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0117
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x015A, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0118
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x015B, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0119
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x015C, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x011A
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x015D, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x011B
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x015E, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x011C
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x015F, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x011D
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0160, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x011E
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0161, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x011F
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0162, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0120
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0163, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0121
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0164, DMI type 20, 19 bytes
+Memory Device Mapped Address
+	Starting Address: 0x000FFFFFC00
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 1 kB
+	Physical Device Handle: 0x0122
+	Memory Array Mapped Address Handle: 0x0124
+	Partition Row Position: Unknown
+	Interleave Position: Unknown
+	Interleaved Data Depth: Unknown
+
+Handle 0x0165, DMI type 23, 13 bytes
+System Reset
+	Status: Enabled
+	Watchdog Timer: Present
+	Boot Option: Do Not Reboot
+	Boot Option On Limit: Do Not Reboot
+	Reset Count: Unknown
+	Reset Limit: Unknown
+	Timer Interval: Unknown
+	Timeout: Unknown
+
+Handle 0x0166, DMI type 24, 5 bytes
+Hardware Security
+	Power-On Password Status: Disabled
+	Keyboard Password Status: Unknown
+	Administrator Password Status: Enabled
+	Front Panel Reset Status: Unknown
+
+Handle 0x0167, DMI type 30, 6 bytes
+Out-of-band Remote Access
+	Manufacturer Name: Intel
+	Inbound Connection: Enabled
+	Outbound Connection: Disabled
+
+Handle 0x0168, DMI type 32, 20 bytes
+System Boot Information
+	Status: No errors detected
+
+Handle 0x0169, DMI type 33, 31 bytes
+64-bit Memory Error Information
+	Type: OK
+	Granularity: Unknown
+	Operation: Unknown
+	Vendor Syndrome: Unknown
+	Memory Array Address: Unknown
+	Device Address: Unknown
+	Resolution: Unknown
+
+Handle 0x016A, DMI type 126, 4 bytes
+Inactive
+
+Handle 0x016B, DMI type 127, 4 bytes
+End Of Table
+

--- a/resources/linux/proc/cpuinfo/oracle-server-6.7-oda
+++ b/resources/linux/proc/cpuinfo/oracle-server-6.7-oda
@@ -1,0 +1,400 @@
+processor	: 0
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 63
+model name	: Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz
+stepping	: 2
+cpu MHz		: 2301.000
+cache size	: 46080 KB
+physical id	: 0
+siblings	: 8
+core id		: 0
+cpu cores	: 4
+apicid		: 0
+initial apicid	: 0
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 15
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 fma cx16 xtpr pdcm dca sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm abm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid fsgsbase smep erms
+bogomips	: 4590.02
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 1
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 63
+model name	: Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz
+stepping	: 2
+cpu MHz		: 2301.000
+cache size	: 46080 KB
+physical id	: 0
+siblings	: 8
+core id		: 1
+cpu cores	: 4
+apicid		: 2
+initial apicid	: 2
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 15
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 fma cx16 xtpr pdcm dca sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm abm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid fsgsbase smep erms
+bogomips	: 4590.02
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 2
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 63
+model name	: Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz
+stepping	: 2
+cpu MHz		: 2301.000
+cache size	: 46080 KB
+physical id	: 0
+siblings	: 8
+core id		: 2
+cpu cores	: 4
+apicid		: 4
+initial apicid	: 4
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 15
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 fma cx16 xtpr pdcm dca sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm abm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid fsgsbase smep erms
+bogomips	: 4590.02
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 3
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 63
+model name	: Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz
+stepping	: 2
+cpu MHz		: 2301.000
+cache size	: 46080 KB
+physical id	: 0
+siblings	: 8
+core id		: 3
+cpu cores	: 4
+apicid		: 6
+initial apicid	: 6
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 15
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 fma cx16 xtpr pdcm dca sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm abm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid fsgsbase smep erms
+bogomips	: 4590.02
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 4
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 63
+model name	: Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz
+stepping	: 2
+cpu MHz		: 2301.000
+cache size	: 46080 KB
+physical id	: 1
+siblings	: 8
+core id		: 0
+cpu cores	: 4
+apicid		: 64
+initial apicid	: 64
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 15
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 fma cx16 xtpr pdcm dca sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm abm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid fsgsbase smep erms
+bogomips	: 4589.04
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 5
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 63
+model name	: Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz
+stepping	: 2
+cpu MHz		: 2301.000
+cache size	: 46080 KB
+physical id	: 1
+siblings	: 8
+core id		: 1
+cpu cores	: 4
+apicid		: 66
+initial apicid	: 66
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 15
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 fma cx16 xtpr pdcm dca sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm abm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid fsgsbase smep erms
+bogomips	: 4589.04
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 6
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 63
+model name	: Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz
+stepping	: 2
+cpu MHz		: 2301.000
+cache size	: 46080 KB
+physical id	: 1
+siblings	: 8
+core id		: 2
+cpu cores	: 4
+apicid		: 68
+initial apicid	: 68
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 15
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 fma cx16 xtpr pdcm dca sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm abm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid fsgsbase smep erms
+bogomips	: 4589.04
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 7
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 63
+model name	: Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz
+stepping	: 2
+cpu MHz		: 2301.000
+cache size	: 46080 KB
+physical id	: 1
+siblings	: 8
+core id		: 3
+cpu cores	: 4
+apicid		: 70
+initial apicid	: 70
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 15
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 fma cx16 xtpr pdcm dca sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm abm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid fsgsbase smep erms
+bogomips	: 4589.04
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 8
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 63
+model name	: Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz
+stepping	: 2
+cpu MHz		: 2301.000
+cache size	: 46080 KB
+physical id	: 0
+siblings	: 8
+core id		: 0
+cpu cores	: 4
+apicid		: 1
+initial apicid	: 1
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 15
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 fma cx16 xtpr pdcm dca sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm abm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid fsgsbase smep erms
+bogomips	: 4590.02
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 9
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 63
+model name	: Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz
+stepping	: 2
+cpu MHz		: 2301.000
+cache size	: 46080 KB
+physical id	: 0
+siblings	: 8
+core id		: 1
+cpu cores	: 4
+apicid		: 3
+initial apicid	: 3
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 15
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 fma cx16 xtpr pdcm dca sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm abm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid fsgsbase smep erms
+bogomips	: 4590.02
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 10
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 63
+model name	: Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz
+stepping	: 2
+cpu MHz		: 2301.000
+cache size	: 46080 KB
+physical id	: 0
+siblings	: 8
+core id		: 2
+cpu cores	: 4
+apicid		: 5
+initial apicid	: 5
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 15
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 fma cx16 xtpr pdcm dca sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm abm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid fsgsbase smep erms
+bogomips	: 4590.02
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 11
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 63
+model name	: Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz
+stepping	: 2
+cpu MHz		: 2301.000
+cache size	: 46080 KB
+physical id	: 0
+siblings	: 8
+core id		: 3
+cpu cores	: 4
+apicid		: 7
+initial apicid	: 7
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 15
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 fma cx16 xtpr pdcm dca sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm abm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid fsgsbase smep erms
+bogomips	: 4590.02
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 12
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 63
+model name	: Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz
+stepping	: 2
+cpu MHz		: 2301.000
+cache size	: 46080 KB
+physical id	: 1
+siblings	: 8
+core id		: 0
+cpu cores	: 4
+apicid		: 65
+initial apicid	: 65
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 15
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 fma cx16 xtpr pdcm dca sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm abm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid fsgsbase smep erms
+bogomips	: 4589.04
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 13
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 63
+model name	: Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz
+stepping	: 2
+cpu MHz		: 2301.000
+cache size	: 46080 KB
+physical id	: 1
+siblings	: 8
+core id		: 1
+cpu cores	: 4
+apicid		: 67
+initial apicid	: 67
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 15
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 fma cx16 xtpr pdcm dca sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm abm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid fsgsbase smep erms
+bogomips	: 4589.04
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 14
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 63
+model name	: Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz
+stepping	: 2
+cpu MHz		: 2301.000
+cache size	: 46080 KB
+physical id	: 1
+siblings	: 8
+core id		: 2
+cpu cores	: 4
+apicid		: 69
+initial apicid	: 69
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 15
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 fma cx16 xtpr pdcm dca sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm abm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid fsgsbase smep erms
+bogomips	: 4589.04
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 15
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 63
+model name	: Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz
+stepping	: 2
+cpu MHz		: 2301.000
+cache size	: 46080 KB
+physical id	: 1
+siblings	: 8
+core id		: 3
+cpu cores	: 4
+apicid		: 71
+initial apicid	: 71
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 15
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 fma cx16 xtpr pdcm dca sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm abm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid fsgsbase smep erms
+bogomips	: 4589.04
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+

--- a/resources/linux/proc/cpuinfo/rhel-6.2-vmware-2vcpus
+++ b/resources/linux/proc/cpuinfo/rhel-6.2-vmware-2vcpus
@@ -1,0 +1,37 @@
+processor    : 0
+vendor_id    : GenuineIntel
+cpu family    : 6
+model        : 42
+model name    : Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+stepping    : 7
+cpu MHz        : 2694.293
+cache size    : 6144 KB
+fpu        : yes
+fpu_exception    : yes
+cpuid level    : 13
+wp        : yes
+flags        : fpu vme de pse tsc msr pae mce cx8 apic mtrr pge mca cmov pat pse36 clflush dts mmx fxsr sse sse2 ss syscall nx rdtscp lm constant_tsc up arch_perfmon pebs bts xtopology tsc_reliable nonstop_tsc aperfmperf unfair_spinlock pni pclmulqdq ssse3 cx16 sse4_1 sse4_2 x2apic popcnt aes xsave avx hypervisor lahf_lm ida arat epb xsaveopt pln pts dts
+bogomips    : 5388.58
+clflush size    : 64
+cache_alignment    : 64
+address sizes    : 40 bits physical, 48 bits virtual
+power management:
+
+processor    : 1
+vendor_id    : GenuineIntel
+cpu family    : 6
+model        : 42
+model name    : Intel(R) Xeon(R) CPU           E7520  @ 1.87GHz
+stepping    : 7
+cpu MHz        : 2694.293
+cache size    : 6144 KB
+fpu        : yes
+fpu_exception    : yes
+cpuid level    : 13
+wp        : yes
+flags        : fpu vme de pse tsc msr pae mce cx8 apic mtrr pge mca cmov pat pse36 clflush dts mmx fxsr sse sse2 ss syscall nx rdtscp lm constant_tsc up arch_perfmon pebs bts xtopology tsc_reliable nonstop_tsc aperfmperf unfair_spinlock pni pclmulqdq ssse3 cx16 sse4_1 sse4_2 x2apic popcnt aes xsave avx hypervisor lahf_lm ida arat epb xsaveopt pln pts dts
+bogomips    : 5388.58
+clflush size    : 64
+cache_alignment    : 64
+address sizes    : 40 bits physical, 48 bits virtual
+power management:

--- a/t/agent/tools/generic.t
+++ b/t/agent/tools/generic.t
@@ -7779,7 +7779,8 @@ my %cpu_tests = (
             MODEL          => '42',
             MANUFACTURER   => 'Intel',
             FAMILYNAME     => 'Core 2 Duo',
-            CORE           => '4'
+            CORE           => '1',
+            CORECOUNT      => '4'
         }
     ],
     'windows-7.2' => [

--- a/t/tasks/inventory/linux/cpu.t
+++ b/t/tasks/inventory/linux/cpu.t
@@ -61,6 +61,65 @@ my %i386 = (
             ID             => 'C2 06 02 00 FF FB EB BF',
         }
     ],
+    # Physical server with 4/18 cores enabled in BIOS depending on Oracle license
+    'oracle-server-6.7-oda' => [
+        {
+            ARCH            => 'i386',
+            CORE            => '4',
+            CORECOUNT       => '18',
+            EXTERNAL_CLOCK  => '100',
+            FAMILYNAME      => 'Xeon',
+            FAMILYNUMBER    => '6',
+            ID              => 'F2 06 03 00 FF FB EB BF',
+            MANUFACTURER    => 'Intel',
+            MODEL           => '63',
+            NAME            => 'Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz',
+            SPEED           => '2300',
+            STEPPING        => '2',
+            THREAD          => '8'
+        },
+        {
+            ARCH            => 'i386',
+            CORE            => '4',
+            CORECOUNT       => '18',
+            EXTERNAL_CLOCK  => '100',
+            FAMILYNAME      => 'Xeon',
+            FAMILYNUMBER    => '6',
+            ID              => 'F2 06 03 00 FF FB EB BF',
+            MANUFACTURER    => 'Intel',
+            MODEL           => '63',
+            NAME            => 'Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz',
+            SPEED           => '2300',
+            STEPPING        => '2',
+            THREAD          => '8'
+        }
+    ],
+    'rhel-6.2-vmware-2vcpus' => [
+        {
+            NAME           => 'Intel(R) Xeon(R) CPU E7520 @ 1.87GHz',
+            MANUFACTURER   => 'Intel',
+            MODEL          => '42',
+            SPEED          => '1870',
+            THREAD         => '1',
+            ARCH           => 'i386',
+            CORE           => '1',
+            STEPPING       => '7',
+            FAMILYNUMBER   => '6',
+            ID             => 'A4 06 01 00 FF FB AB 0F',
+        },
+        {
+            NAME           => 'Intel(R) Xeon(R) CPU E7520 @ 1.87GHz',
+            MANUFACTURER   => 'Intel',
+            MODEL          => '42',
+            SPEED          => '1870',
+            THREAD         => '1',
+            ARCH           => 'i386',
+            CORE           => '1',
+            STEPPING       => '7',
+            FAMILYNUMBER   => '6',
+            ID             => 'A4 06 00 00 FF FB AB 0F',
+        }
+    ],
     'rhel-6.3-esx-1vcpu' => [
         {
             NAME           => 'Intel(R) Core(TM) i5-2500S CPU @ 2.70GHz',

--- a/t/tasks/inventory/windows/cpu.t
+++ b/t/tasks/inventory/windows/cpu.t
@@ -42,7 +42,8 @@ my %tests = (
             MODEL        => '42',
             SPEED        => '2800',
             THREAD       => '1',
-            CORE         => '4'
+            CORE         => '1',
+            CORECOUNT    => '4'
         }
     ],
     '2003' => [


### PR DESCRIPTION
Add CORECOUNT support based on dmidecode output:
 - dmidecode 'Core Enabled' is now the default extracted CORE
 - Add dmidecode 'Core Count' as CORECOUNT if different than CORE

This patch will permit to show total available cores on physical machine with core disabled by Bios.