### PR TITLE
Mac Os X refacto using XML::XPath

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,7 +23,7 @@ requires 'Text::Template'     => '0';
 requires 'UNIVERSAL::require' => '0';
 requires 'XML::TreePP'        => '0.26';
 if ($OSNAME =~ /darwin/i) {
-    requires 'Tie::IxHash'        => '0';
+    requires 'XML::XPath'        => '0';
 }
 
 if ($OSNAME eq 'MSWin32') {

--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,6 @@ dependencies:
     - $HOME/perl5/bin/cpanm -L ~/perl5 Test::More
     - $HOME/perl5/bin/cpanm -L ~/perl5 UNIVERSAL::require
     - $HOME/perl5/bin/cpanm -L ~/perl5 File::Copy::Recursive
-    - $HOME/perl5/bin/cpanm -L ~/perl5 XML::XPath
     - perl Makefile.PL
     - make
 

--- a/circle.yml
+++ b/circle.yml
@@ -21,6 +21,7 @@ dependencies:
     - $HOME/perl5/bin/cpanm -L ~/perl5 Test::More
     - $HOME/perl5/bin/cpanm -L ~/perl5 UNIVERSAL::require
     - $HOME/perl5/bin/cpanm -L ~/perl5 File::Copy::Recursive
+    - $HOME/perl5/bin/cpanm -L ~/perl5 XML::XPath
     - perl Makefile.PL
     - make
 

--- a/lib/FusionInventory/Agent/Task/Inventory/MacOS/Softwares.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/MacOS/Softwares.pm
@@ -44,9 +44,9 @@ sub _getSoftwaresList {
     }
     my $localTimeOffset = FusionInventory::Agent::Tools::MacOS::detectLocalTimeOffset();
     $infos = FusionInventory::Agent::Tools::MacOS::getSystemProfilerInfos(
+        %params,
         type            => 'SPApplicationsDataType',
-        localTimeOffset => $localTimeOffset,
-        @_
+        localTimeOffset => $localTimeOffset
     );
 
     my $info = $infos->{Applications};

--- a/lib/FusionInventory/Agent/Tools/MacOS.pm
+++ b/lib/FusionInventory/Agent/Tools/MacOS.pm
@@ -60,7 +60,10 @@ sub _getSystemProfilerInfosXML {
     #    my $xmlStr = join '', @xml;
     my $info = {};
     if ($params{type} eq 'SPApplicationsDataType') {
-        $info->{Applications} = _extractSoftwaresFromXml(%params);
+        $info->{Applications} = _extractSoftwaresFromXml(
+            %params,
+            xmlString => $xmlStr
+        );
     } else {
         # not implemented for every data types
     }

--- a/lib/FusionInventory/Agent/Tools/MacOS.pm
+++ b/lib/FusionInventory/Agent/Tools/MacOS.pm
@@ -79,7 +79,7 @@ sub _extractSoftwaresFromXml {
     return unless $xmlParser;
 
     my $softwaresHash = {};
-    my $n = $xmlParser->findnodes('/plist/array[1]/dict[1]/array[1]/dict');
+    my $n = $xmlParser->findnodes("/plist/array[1]/dict[1]/key[text()='_items']/following-sibling::array[1]/descendant::dict");
     my @nl = $n->get_nodelist();
     for my $elem (@nl) {
         $softwaresHash = _mergeHashes($softwaresHash, _extractSoftwareDataFromXmlNode($elem, $params{logger}, $params{localTimeOffset}));

--- a/lib/FusionInventory/Agent/Tools/MacOS.pm
+++ b/lib/FusionInventory/Agent/Tools/MacOS.pm
@@ -44,7 +44,7 @@ sub _initXmlParser {
     } elsif ($params{file}) {
         $xmlParser = XML::XPath->new(filename => $params{file});
     }
-    return int($xmlParser);
+    return $xmlParser;
 }
 
 sub _getSystemProfilerInfosXML {

--- a/lib/FusionInventory/Agent/Tools/MacOS.pm
+++ b/lib/FusionInventory/Agent/Tools/MacOS.pm
@@ -74,9 +74,8 @@ sub _getSystemProfilerInfosXML {
 sub _extractSoftwaresFromXml {
     my (%params) = @_;
 
-    unless ($xmlParser) {
-        _initXmlParser(%params);
-    }
+    _initXmlParser(%params);
+
     return unless $xmlParser;
 
     my $softwaresHash = {};

--- a/lib/FusionInventory/Agent/Tools/MacOS.pm
+++ b/lib/FusionInventory/Agent/Tools/MacOS.pm
@@ -41,7 +41,7 @@ sub _initXmlParser {
     }
     if ($params{xmlString}) {
         $xmlParser = XML::XPath->new(xml => $params{xmlString});
-    } else {
+    } elsif ($params{file}) {
         $xmlParser = XML::XPath->new(filename => $params{file});
     }
     return int($xmlParser);

--- a/t/agent/tools/macos.t
+++ b/t/agent/tools/macos.t
@@ -3386,7 +3386,7 @@ my $versionNumbersComparisons = [
 plan tests =>
     scalar (keys %system_profiler_tests) +
     scalar @ioreg_tests
-    + 16
+    + 11
     + scalar (@$versionNumbersComparisons);
 
 foreach my $test (keys %system_profiler_tests) {
@@ -3491,103 +3491,24 @@ for my $listVersionNumbers (@$versionNumbersComparisons) {
 }
 ok (FusionInventory::Agent::Tools::MacOS::cmpVersionNumbers('5.34.54', '5.34.54') == 0);
 
-my $xmlString = <<XMLSTRING;
-<root>
-    <elem>
-        <name>name1.1</name>
-        <value>value1.1</value>
-        <name>name1.2</name>
-        <value>value1.2</value>
-        <name>name1.3</name>
-        <value>value1.3</value>
-    </elem>
-    <elem>
-        <elem>
-            <name>name2-1.1</name>
-            <value>value2-1.1</value>
-            <name>name2-1.2</name>
-            <value>value2-1.2</value>
-            <name>name2-1.3</name>
-            <value>value2-1.3</value>
-        </elem>
-    </elem>
-    <elem>
-        <elem>
-            <elem>
-                <name>name3-1-1.1</name>
-                <value>value3-1-1.1</value>
-                <name>name3-1-1.2</name>
-                <value>value3-1-1.2</value>
-                <name>name3-1-1.3</name>
-                <value>value3-1-1.3</value>
-            </elem>
-        </elem>
-        <elem>
-            <name>name3-2.1</name>
-            <value>value3-2.1</value>
-            <name>name3-2.2</name>
-            <value>value3-2.2</value>
-            <name>name3-2.3</name>
-            <value>value3-2.3</value>
-        </elem>
-    </elem>
-    <elem>
-        <name>name4.1</name>
-        <value>value4.1</value>
-        <name>name4.2</name>
-        <value>value4.2</value>
-        <name>name4.3</name>
-        <value>value4.3</value>
-        <name>name4.4</name>
-        <value></value>
-        <name>name4.5</name>
-        <value>value4.5</value>
-    </elem>
-</root>
-XMLSTRING
-
-my $hash;
-SKIP : {
-    skip 'test only if module Tie::IxHash available', 7 unless $checkTieIxHash;
-
-    $hash = FusionInventory::Agent::Tools::MacOS::_parseXmlStringKeepingOrder($xmlString);
-    ok (defined($$hash{root}));
-    ok (defined($$hash{root}{elem}[2]{elem}[0]{elem}));
-
-    $xmlString = FusionInventory::Agent::Tools::getAllLines(
-        file => 'resources/macos/system_profiler/10.8-system_profiler_SPApplicationsDataType_-xml.example.xml'
-    );
-
-    $type = 'SPApplicationsDataType';
-    my $softwaresHash = FusionInventory::Agent::Tools::MacOS::_extractDataFromXmlString($xmlString, $type, 7200);
-    ok (defined($softwaresHash));
-
-    $expectedHash = {
-        'Programme d’installation' => {
-            '64-Bit (Intel)'  => 'Yes',
-            'Get Info String' => '3.0, Copyright © 2000-2006 Apple Computer Inc., All Rights Reserved',
-            'Last Modified'   => '27/06/2009',
-            'Location'        => '/System/Library/CoreServices/Installer.app',
-            'Kind'            => 'Universal',
-            'Version'         => '4.0'
-        }
-    };
-    cmp_deeply(
-        $expectedHash->{"Programme d’installation"},
-        $softwaresHash->{Applications}->{"Programme d’installation"}
-    );
-    ok (scalar(keys %{$softwaresHash->{Applications}}) == 291, "we expect 291 elements and got " . (scalar (keys %{$softwaresHash->{Applications}})));
-
-    $hash = FusionInventory::Agent::Tools::MacOS::_parseXmlStringKeepingOrder($xmlString);
-    my $subArray = FusionInventory::Agent::Tools::MacOS::_findElementAndReturnParentArray(undef, $hash, 'key', '_name');
-    ok ($subArray);
-    my $size = scalar(@$subArray);
-    ok ($size == 291, 'must be 291 and is '.$size);
-}
-
 SKIP : {
     skip 'MacOS specific test', 1 unless $OSNAME eq 'darwin';
 
     my $boottime = getBootTime();
     ok ($boottime);
+}
+
+XML::XPath->require();
+my $checkXmlXPath = $EVAL_ERROR ? 0 : 1;
+SKIP : {
+    skip 'test only if module XML::XPath available', 2 unless $checkXmlXPath;
+
+    FusionInventory::Agent::Tools::MacOS::_initXmlParser(
+        file => 'resources/macos/system_profiler/10.8-system_profiler_SPApplicationsDataType_-xml.example.xml'
+    );
+    my $softs = FusionInventory::Agent::Tools::MacOS::_extractSoftwaresFromXml(
+        localTimeOffset => 7200
+    );
+    ok ($softs);
+    ok (scalar(keys %$softs) == 291, 'must be 291 and is ' . scalar(keys %$softs));
 }

--- a/t/agent/tools/macos.t
+++ b/t/agent/tools/macos.t
@@ -3407,10 +3407,10 @@ my $softwaresFromFlatFile = FusionInventory::Agent::Tools::MacOS::_getSystemProf
 my $xmlFile = 'resources/macos/system_profiler/10.8-system_profiler_SPApplicationsDataType_-xml.example.xml';
 my $softwaresFromXmlFile = FusionInventory::Agent::Tools::MacOS::_getSystemProfilerInfosXML(file => $xmlFile, type => $type, localTimeOffset => 7200);
 
-Tie::IxHash->require();
-my $checkTieIxHash = $EVAL_ERROR ? 0 : 1;
+XML::XPath->require();
+my $checkXmlXPath = $EVAL_ERROR ? 0 : 1;
 SKIP : {
-    skip 'test only if module Tie::IxHash available', 4 unless $checkTieIxHash;
+    skip 'test only if module Tie::IxHash available', 6 unless $checkXmlXPath;
 
     ok (ref($softwaresFromFlatFile) eq 'HASH');
     ok (ref($softwaresFromXmlFile) eq 'HASH');
@@ -3440,6 +3440,15 @@ SKIP : {
     my $softwaresFromXmlFileSize = scalar(keys %{$softwaresFromXmlFile->{'Applications'}});
     ok ($softwaresFromFlatFileSize == $softwaresFromXmlFileSize,
         $softwaresFromFlatFileSize.' from flat file and '.$softwaresFromXmlFileSize.' from XML file');
+
+    FusionInventory::Agent::Tools::MacOS::_initXmlParser(
+        file => 'resources/macos/system_profiler/10.8-system_profiler_SPApplicationsDataType_-xml.example.xml'
+    );
+    my $softs = FusionInventory::Agent::Tools::MacOS::_extractSoftwaresFromXml(
+        localTimeOffset => 7200
+    );
+    ok ($softs);
+    ok (scalar(keys %$softs) == 291, 'must be 291 and is ' . scalar(keys %$softs));
 }
 
 my $extractedHash = {
@@ -3496,19 +3505,4 @@ SKIP : {
 
     my $boottime = getBootTime();
     ok ($boottime);
-}
-
-XML::XPath->require();
-my $checkXmlXPath = $EVAL_ERROR ? 0 : 1;
-SKIP : {
-    skip 'test only if module XML::XPath available', 2 unless $checkXmlXPath;
-
-    FusionInventory::Agent::Tools::MacOS::_initXmlParser(
-        file => 'resources/macos/system_profiler/10.8-system_profiler_SPApplicationsDataType_-xml.example.xml'
-    );
-    my $softs = FusionInventory::Agent::Tools::MacOS::_extractSoftwaresFromXml(
-        localTimeOffset => 7200
-    );
-    ok ($softs);
-    ok (scalar(keys %$softs) == 291, 'must be 291 and is ' . scalar(keys %$softs));
 }


### PR DESCRIPTION
Mac Os X software retrieving refactoring, now using XML::XPath to parse system_profiler XML output, and as a consequence, cleaning a few functions