### PR TITLE
NetInventory: Check LldpChassisIDSubtype

### DIFF
--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -1288,8 +1288,10 @@ sub _getLLDPInfo {
     my (%params) = @_;
 
     my $snmp   = $params{snmp};
+    my $logger = $params{logger};
 
     my $results;
+    my $ChassisIdSubType = $snmp->walk('.1.0.8802.1.1.2.1.4.1.1.4');
     my $lldpRemChassisId = $snmp->walk('.1.0.8802.1.1.2.1.4.1.1.5');
     my $lldpRemPortId    = $snmp->walk('.1.0.8802.1.1.2.1.4.1.1.7');
     my $lldpRemPortDesc  = $snmp->walk('.1.0.8802.1.1.2.1.4.1.1.8');
@@ -1308,6 +1310,17 @@ sub _getLLDPInfo {
     while (my ($suffix, $mac) = each %{$lldpRemChassisId}) {
         my $sysdescr = _getCanonicalString($lldpRemSysDesc->{$suffix});
         next unless $sysdescr;
+
+        # We only support macAddress as LldpChassisIdSubtype at the moment
+        my $subtype = $ChassisIdSubType->{$suffix}
+            or next;
+        unless ($subtype eq '4') {
+            $logger->warning(
+                "ChassisId subtype $subtype not supported for <$sysdescr>, value was " .
+                ($mac||"n/a") . ", please report this issue"
+            );
+            next;
+        }
 
         my $connection = {
             SYSMAC   => lc(alt2canonical($mac)),

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -1312,13 +1312,12 @@ sub _getLLDPInfo {
         next unless $sysdescr;
 
         # We only support macAddress as LldpChassisIdSubtype at the moment
-        my $subtype = $ChassisIdSubType->{$suffix}
-            or next;
+        my $subtype = $ChassisIdSubType->{$suffix} || "n/a";
         unless ($subtype eq '4') {
-            $logger->warning(
+            $logger->debug(
                 "ChassisId subtype $subtype not supported for <$sysdescr>, value was " .
                 ($mac||"n/a") . ", please report this issue"
-            );
+            ) if $logger;
             next;
         }
 


### PR DESCRIPTION
Attempt to fix #252 as only macAddress LldpChassiIdSubtype was really supported