### PR TITLE
Service/daemon refactoring

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,14 @@
 Revision history for FusionInventory agent
 
+2.3.21 not released
+core:
+* Service/daemon refactoring:
+ * Move all daemon method to dedicated FusionInventory::Agent::Daemon package
+ * Win32 service now based on private FusionInventory::Agent::Service inheriting
+   from FusionInventory::Agent::Daemon
+* daemon process renamed to provider derivated name under unix-like systems with
+tag if defined. Example: "fusioniventory-agent (prod)"
+
 2.3.20 Thu, 1 Jun 2017
 core:
 * Fix #224, #254, #268

--- a/bin/fusioninventory-win32-service
+++ b/bin/fusioninventory-win32-service
@@ -100,13 +100,8 @@ if ($options->{register}) {
     exit($ret);
 }
 
-FusionInventory::Agent->require()
-    or die "Can't load FusionInventory::Agent";
-
-# Setup sigterm callback to exit thread
-$setup{sigterm} = sub { threads->exit(); };
-
-my $agent_as_context = FusionInventory::Agent->new( %setup );
+my $agent_as_context = FusionInventory::Agent::Service->new( %setup )
+    or die "Can't create FusionInventory::Agent::Service object: $!";
 
 $agent_as_context->{last_state} = SERVICE_START_PENDING;
 
@@ -129,17 +124,9 @@ Win32::Daemon::StartService($agent_as_context, SERVICE_SLEEP_TIME);
 sub cb_start {
     my( $event, $agent ) = @_;
 
-    if (!exists($agent->{agent_thread})) {
-
-        # First start a thread dedicated to Win32::OLE calls
-        FusionInventory::Agent::Tools::Win32->require();
-        FusionInventory::Agent::Tools::Win32::start_Win32_OLE_Worker();
-
-        $agent->{agent_thread} = threads->create(sub {
-            $agent->init(options => { service => 1 });
-            $agent->run();
-        });
-    }
+    # Start service dedicated thread only if required
+    $agent->{agent_thread} = $agent->start_service()
+        unless (exists($agent->{agent_thread}));
 
     Win32::Daemon::CallbackTimer(SERVICE_SLEEP_TIME);
 
@@ -206,6 +193,64 @@ sub cb_interrogate {
     Win32::Daemon::State($agent->{last_state});
 }
 
+# We need to override default terminate method
+package FusionInventory::Agent::Service;
+
+use FusionInventory::Agent::Version;
+use FusionInventory::Agent::Logger;
+use FusionInventory::Agent::Tools::Win32;
+
+use base 'FusionInventory::Agent::Daemon';
+
+my $PROVIDER = $FusionInventory::Agent::Version::PROVIDER;
+
+sub start_service {
+    my ($self) = @_;
+
+    # First start a thread dedicated to Win32::OLE calls
+    FusionInventory::Agent::Tools::Win32::start_Win32_OLE_Worker();
+
+    # Start run in a dedicated thread
+    return threads->create(sub {
+        $self->init(options => { service => 1 });
+        $self->run()
+    });
+}
+
+sub ApplyServiceOptimizations {
+    my ($self) = @_;
+
+    $self->SUPER::ApplyServiceOptimizations();
+
+    # Win32 only service optimization
+
+    # Preload is64bit result to avoid a lot of WMI calls
+    is64bit();
+}
+
+sub RunningServiceOptimization {
+    my ($self) = @_;
+
+    # win32 platform needs optimization
+    if ($self->{logger}->{verbosity} >= LOG_DEBUG) {
+        my $runmem = getAgentMemorySize();
+        $self->{logger}->debug("Agent memory usage before freeing memory: $runmem");
+    }
+
+    # Free some memory
+    FreeAgentMem();
+
+    my $current_mem = getAgentMemorySize();
+    $self->{logger}->info("$PROVIDER Agent memory usage: $current_mem");
+}
+
+sub terminate {
+    my ($self) = @_;
+
+    $self->SUPER::terminate();
+
+    threads->exit();
+}
 
 __END__
 
@@ -232,5 +277,5 @@ B<fusioninventory-win32-service> [--register|--delete|--help] [options]
 
   Samples to use from sources:
     perl bin/fusioninventory-win32-service --help
-    perl bin/fusioninventory-win32-service --register -n fia-test -d "[TEST] FIA 2.3.18"
+    perl bin/fusioninventory-win32-service --register -n fia-test -d "[TEST] FIA Service"
     perl bin/fusioninventory-win32-service --delete -n fia-test

--- a/lib/FusionInventory/Agent/Daemon.pm
+++ b/lib/FusionInventory/Agent/Daemon.pm
@@ -1,0 +1,222 @@
+package FusionInventory::Agent::Daemon;
+
+use strict;
+use warnings;
+
+use Cwd;
+use English qw(-no_match_vars);
+use UNIVERSAL::require;
+use POSIX ":sys_wait_h"; # WNOHANG
+
+use base 'FusionInventory::Agent';
+
+use FusionInventory::Agent::Logger;
+use FusionInventory::Agent::Version;
+use FusionInventory::Agent::Tools;
+use FusionInventory::Agent::Tools::Generic;
+
+my $PROVIDER = $FusionInventory::Agent::Version::PROVIDER;
+
+sub run {
+    my ($self) = @_;
+
+    $self->{status} = 'waiting';
+
+    my @targets = $self->getTargets();
+
+    $self->{logger}->debug("Running in background mode");
+
+    # background mode: work on a targets list copy, but loop while
+    # the list really exists so we can stop quickly when asked for
+    while ($self->getTargets()) {
+        my $time = time();
+
+        @targets = $self->getTargets() unless @targets;
+        my $target = shift @targets;
+
+        $self->_reloadConfIfNeeded();
+
+        if ($time >= $target->getNextRunDate()) {
+
+            my $net_error = 0;
+            eval {
+                $net_error = $self->runTarget($target);
+            };
+            $self->{logger}->error($EVAL_ERROR) if $EVAL_ERROR;
+            if ($net_error) {
+                # Prefer to retry early on net error
+                $target->setNextRunDateFromNow(60);
+            } else {
+                $target->resetNextRunDate();
+            }
+
+            # Leave immediately if we passed in terminate method
+            last unless $self->getTargets();
+
+            # Call service optimization after each target run
+            $self->RunningServiceOptimization();
+        }
+
+        # This eventually check for http messages, default timeout is 1 second
+        $self->sleep(1);
+    }
+}
+
+sub runTask {
+    my ($self, $target, $name, $response) = @_;
+
+    $self->{status} = "running task $name";
+
+    # server mode: run each task in a child process
+    if (my $pid = fork()) {
+
+        # parent
+        $self->{current_runtask} = $pid;
+
+        while (waitpid($pid, WNOHANG) == 0) {
+            # Wait but eventually handle http server requests
+            $self->sleep(1);
+
+            # Leave earlier while requested
+            last unless $self->getTargets();
+        }
+        delete $self->{current_runtask};
+
+    } else {
+        # child
+        die "fork failed: $ERRNO" unless defined $pid;
+
+        $self->{logger}->debug("forking process $pid to handle task $name");
+
+        $self->runTaskReal($target, $name, $response);
+
+        exit(0);
+    }
+}
+
+sub createDaemon {
+    my ($self) = @_;
+
+    my $config = $self->{config};
+    my $logger = $self->{logger};
+
+    my $pidfile = $config->{pidfile} ||
+        $self->{vardir} . '/'.lc($PROVIDER).'.pid';
+
+    # Don't create a daemon if still started as a service
+    return if $config->{'service'};
+
+    if ($self->isAlreadyRunning($pidfile)) {
+        $logger->error("$PROVIDER Agent is already running, exiting...") if $logger;
+        exit 1;
+    }
+
+    if (!$config->{'no-fork'}) {
+
+        Proc::Daemon->require();
+        if ($EVAL_ERROR) {
+            $logger->error("Failed to load Proc::Daemon: $EVAL_ERROR") if $logger;
+            exit 1;
+        }
+
+        # If we use relative path, we must stay in the current directory
+        my $workdir = substr($self->{libdir}, 0, 1) eq '/' ? '/' : getcwd();
+
+        Proc::Daemon::Init(
+            {
+                work_dir => $workdir,
+                pid_file => $pidfile
+            }
+        );
+
+        $logger->debug("$PROVIDER Agent daemonized") if $logger;
+    }
+}
+
+sub isAlreadyRunning {
+    my ($self, $pidfile) = @_;
+
+    Proc::PID::File->require();
+    if ($EVAL_ERROR) {
+        $self->{logger}->debug(
+            'Proc::PID::File unavailable, unable to check for running agent'
+        );
+        return 0;
+    }
+
+    my $pid = Proc::PID::File->new();
+    $pid->{path} = $pidfile;
+    return $pid->alive();
+}
+
+sub sleep {
+    my ($self, $delay) = @_;
+
+    if ($self->{server}) {
+        # Check for http interface messages, default timeout is 1 second
+        $self->{server}->handleRequests() or delay(1);
+    } else {
+        delay(1);
+    }
+}
+
+sub loadHttpInterface {
+    my ($self) = @_;
+
+    my $config = $self->{config};
+
+    return if $config->{'no-httpd'};
+
+    my $logger = $self->{logger};
+
+    FusionInventory::Agent::HTTP::Server->require();
+    if ($EVAL_ERROR) {
+        $logger->error("Failed to load HTTP server: $EVAL_ERROR");
+    } else {
+        $self->{server} = FusionInventory::Agent::HTTP::Server->new(
+            logger          => $logger,
+            agent           => $self,
+            htmldir         => $self->{datadir} . '/html',
+            ip              => $config->{'httpd-ip'},
+            port            => $config->{'httpd-port'},
+            trust           => $config->{'httpd-trust'}
+        );
+        $self->{server}->init();
+    }
+}
+
+sub resetLastConfigLoad {
+    my ($self) = @_;
+
+    $self->ApplyServiceOptimizations();
+
+    $self->SUPER::resetLastConfigLoad();
+}
+
+sub ApplyServiceOptimizations {
+    my ($self) = @_;
+
+    return unless ($self->{config}->{daemon} || $self->{config}->{service});
+
+    # Preload all IDS databases to avoid reload them all the time during inventory
+    if (grep { /^inventory$/i } @{$self->{tasksExecutionPlan}}) {
+        my %datadir = ( datadir => $self->{datadir} );
+        getPCIDeviceVendor(%datadir);
+        getUSBDeviceVendor(%datadir);
+        getEDIDVendor(%datadir);
+    }
+}
+
+sub RunningServiceOptimization {
+    my ($self) = @_;
+}
+
+sub terminate {
+    my ($self) = @_;
+
+    $self->{logger}->info("$PROVIDER Agent exiting");
+
+    $self->SUPER::terminate();
+}
+
+1;


### PR DESCRIPTION
Refactoring:
 * Move all daemon method to dedicated FusionInventory::Agent::Daemon package
 * Win32 service now based on private FusionInventory::Agent::Service inheriting from FusionInventory::Agent::Daemon

Feature added:
Daemon process renamed to provider derivated name under unix-like systems with tag if defined.
Example: "fusioniventory-agent (prod)" will be seen with `ps` command if `tag` was set to `prod`