### PR TITLE
Battery data: complete dmidecode missing data with data from 'upower'

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/Generic/Dmidecode/Battery.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Generic/Dmidecode/Battery.pm
@@ -154,6 +154,8 @@ sub _getBatteryDataFromUpower {
 sub _mergeData {
     my ($batt, $additionalData) = @_;
 
+    return $batt unless $additionalData;
+
     if ($additionalData->{NAME} && !$batt->{NAME}) {
         $batt->{NAME} = $additionalData->{NAME};
         if ($batt->{MANUFACTURER}) {

--- a/lib/FusionInventory/Agent/Task/Inventory/Generic/Dmidecode/Battery.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Generic/Dmidecode/Battery.pm
@@ -20,6 +20,9 @@ sub doInventory {
 
     my $battery = _getBattery(logger => $logger);
 
+    my $batteryAdditionalData = _getBatteryFromUpower(%params);
+    $battery = _mergeData($battery, $batteryAdditionalData);
+
     return unless $battery;
 
     $inventory->addEntry(
@@ -84,6 +87,84 @@ sub _parseDate {
         return "$day/$month/$year";
     }
     return;
+}
+
+sub _getBatteryFromUpower {
+    my (%params) = @_;
+
+    my $command = 'upower';
+    return unless canRun($command);
+
+    my $batteryName = _getBatteryNameFromUpower(
+        %params,
+        command => $command . ' --enumerate'
+    );
+
+    return unless $batteryName;
+
+    my $battData = _getBatteryDataFromUpower(
+        %params,
+        command => $command . ' -i ' . $batteryName
+    );
+
+    return $battData;
+}
+
+sub _getBatteryNameFromUpower {
+    my (%params) = @_;
+
+    my @lines = getAllLines(
+        %params
+    );
+
+    my $battName;
+    for my $line (@lines) {
+        if ($line =~ /^(.*\/battery_BAT1)$/) {
+            $battName = $1;
+            last;
+        }
+    }
+
+    return $battName;
+}
+
+sub _getBatteryDataFromUpower {
+    my (%params) = @_;
+
+    my @lines = getAllLines(
+        %params
+    );
+
+    my $data = {};
+    for my $line (@lines) {
+        if ($line =~ /^\s*(\S+):\s*(\S+)$/) {
+            $data->{$1} = $2;
+        }
+    }
+    my $battData = {
+        NAME => $data->{model} || '',
+        CAPACITY => $data->{'energy-full'},
+        VOLTAGE => $data->{voltage},
+        CHEMISTRY => $data->{technology}
+    };
+
+    return $battData;
+}
+
+sub _mergeData {
+    my ($batt, $additionalData) = @_;
+
+    if ($additionalData->{NAME} && !$batt->{NAME}) {
+        $batt->{NAME} = $additionalData->{NAME};
+        if ($batt->{MANUFACTURER}) {
+            $batt->{NAME} = $batt->{MANUFACTURER} . ' ' . $batt->{NAME};
+        }
+    }
+    $batt->{CHEMISTRY} = $additionalData->{CHEMISTRY} if ($additionalData->{CHEMISTRY} && !($batt->{CHEMISTRY}));
+    $batt->{CAPACITY} = $additionalData->{CAPACITY} if ($additionalData->{CAPACITY} && !($batt->{CAPACITY}));
+    $batt->{VOLTAGE} = $additionalData->{VOLTAGE} if ($additionalData->{VOLTAGE} && !($batt->{VOLTAGE}));
+
+    return $batt;
 }
 
 1;

--- a/lib/FusionInventory/Agent/Task/Inventory/Generic/Dmidecode/Battery.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Generic/Dmidecode/Battery.pm
@@ -137,7 +137,7 @@ sub _getBatteryDataFromUpower {
 
     my $data = {};
     for my $line (@lines) {
-        if ($line =~ /^\s*(\S+):\s*(\S+)$/) {
+        if ($line =~ /^\s*(\S+):\s*(\S+(?:\s+\S+)*)$/) {
             $data->{$1} = $2;
         }
     }

--- a/lib/FusionInventory/Agent/Tools/Generic.pm
+++ b/lib/FusionInventory/Agent/Tools/Generic.pm
@@ -79,6 +79,11 @@ sub getDmidecodeInfos {
     }
     close $handle;
 
+    # push last block in list if still defined
+    if ($block) {
+        push(@{$info->{$type}}, $block);
+    }
+
     # do not return anything if dmidecode output is obviously truncated
     return if keys %$info < 2;
 

--- a/resources/generic/upower/dmi_decode.txt
+++ b/resources/generic/upower/dmi_decode.txt
@@ -1,6 +1,10 @@
 Getting SMBIOS data from sysfs.
 SMBIOS 2.6 present.
 
+# Next 2 lines have been added in order to permit function to return the data
+Handle 0x0014, DMI type 1, 26 bytes
+    key: value
+
 Handle 0x0014, DMI type 22, 26 bytes
 Portable Battery
 	Location: 1st Battery

--- a/resources/generic/upower/dmi_decode.txt
+++ b/resources/generic/upower/dmi_decode.txt
@@ -1,0 +1,16 @@
+Getting SMBIOS data from sysfs.
+SMBIOS 2.6 present.
+
+Handle 0x0014, DMI type 22, 26 bytes
+Portable Battery
+	Location: 1st Battery
+	Manufacturer: TOSHIBA
+	Manufacture Date: **/**/****
+	Serial Number: 0000000000
+	Name:
+	Design Capacity: Unknown
+	Design Voltage: Unknown
+	SBDS Version: Not Specified
+	Maximum Error: Unknown
+	SBDS Chemistry: Li-ION
+	OEM-specific Information: 0x00000000

--- a/resources/generic/upower/enumerate_1.txt
+++ b/resources/generic/upower/enumerate_1.txt
@@ -1,0 +1,4 @@
+/org/freedesktop/UPower/devices/line_power_ADP1
+/org/freedesktop/UPower/devices/battery_BAT1
+/org/freedesktop/UPower/devices/mouse_0003o046Do1017x0006
+/org/freedesktop/UPower/devices/DisplayDevice

--- a/resources/generic/upower/infos_1.txt
+++ b/resources/generic/upower/infos_1.txt
@@ -1,0 +1,22 @@
+native-path:          BAT1
+  model:                G71C000G7210
+  serial:               0
+  power supply:         yes
+  updated:              mar. 21 févr. 2017 10:20:29 CET (1 seconds ago)
+  has history:          yes
+  has statistics:       yes
+  battery
+    present:             yes
+    rechargeable:        yes
+    state:               fully-charged
+    warning-level:       none
+    energy:              39,264 Wh
+    energy-empty:        0 Wh
+    energy-full:         39,264 Wh
+    energy-full-design:  51,504 Wh
+    energy-rate:         0 W
+    voltage:             14,8 V
+    percentage:          100%
+    capacity:            76,2349%
+    technology:          lithium-ion
+    icon-name:          'battery-full-charged-symbolic'

--- a/t/agent/tools/generic.t
+++ b/t/agent/tools/generic.t
@@ -1150,6 +1150,12 @@ my %dmidecode_tests = (
                 'Current Interleave' => 'One-way Interleave',
                 'Memory Module Voltage' => '5.0 V 3.3 V'
             }
+        ],
+        13 => [
+            {
+                'Installable Languages' => '3',
+                'Currently Installed Language' => 'en|US|iso8859-1'
+            }
         ]
     },
     'openbsd-3.8' => {
@@ -1882,6 +1888,20 @@ my %dmidecode_tests = (
                  'Error Information Handle' => 'No Error',
                  'Locator' => 'DIMM 2',
                  'Form Factor' => 'DIMM'
+            },
+            {
+                'Array Handle' => '0x0022',
+                'Error Information Handle' => 'No Error',
+                'Total Width' => '72 bits',
+                'Data Width' => '64 bits',
+                'Size' => '512 MB',
+                'Form Factor' => 'DIMM',
+                'Set' => '2',
+                'Locator' => 'DIMM 3',
+                'Bank Locator' => 'BANK 2',
+                'Type' => 'DDR',
+                'Type Detail' => 'Synchronous',
+                'Speed' => '400 MHz (2.5 ns)',
             }
         ],
         12 => [

--- a/t/tasks/inventory/generic/dmidecode/battery.t
+++ b/t/tasks/inventory/generic/dmidecode/battery.t
@@ -50,16 +50,29 @@ my %tests = (
     'windows-hyperV' => undef
 );
 
-my %testUpower = (
+my %testUpowerEnumerate = (
     'enumerate_1.txt' => {
-        extractedName => '/org/freedesktop/UPower/devices/battery_BAT1'
+        extractedName     => '/org/freedesktop/UPower/devices/battery_BAT1',
+    }
+);
+
+my %testUpowerInfos = (
+    'infos_1.txt' => {
+        extractedData => {
+            NAME      => 'G71C000G7210',
+            CAPACITY  => '39,264 Wh',
+            VOLTAGE   => '14,8 V',
+            CHEMISTRY => 'lithium-ion'
+        }
     }
 );
 
 plan tests =>
     (scalar keys %tests)               +
     (scalar grep { $_ } values %tests) +
-    2;
+    scalar (keys %testUpowerEnumerate) +
+    scalar (keys %testUpowerInfos) +
+    1;
 
 my $inventory = FusionInventory::Test::Inventory->new();
 
@@ -73,10 +86,24 @@ foreach my $test (keys %tests) {
     } "$test: registering";
 }
 
-foreach my $test (keys %testUpower) {
-    my $file = 'resources/generic/upower/' . $test;
-    my $battName =  FusionInventory::Agent::Task::Inventory::Generic::Dmidecode::Battery::_getBatteryNameFromUpower(
+foreach my $test (keys %testUpowerEnumerate) {
+    my $file = 'resources/generic/upower/'.$test;
+    my $battName = FusionInventory::Agent::Task::Inventory::Generic::Dmidecode::Battery::_getBatteryNameFromUpower(
         file => $file
     );
-    ok ($battName eq $testUpower{$test}->{extractedName});
+    ok ($battName eq $testUpowerEnumerate{$test}->{extractedName}, "$test: _getBatteryNameFromUpower()");
 }
+
+foreach my $test (keys %testUpowerInfos) {
+    my $file = 'resources/generic/upower/' . $test;
+    my $battData = FusionInventory::Agent::Task::Inventory::Generic::Dmidecode::Battery::_getBatteryDataFromUpower(
+        file => $file
+    );
+    cmp_deeply(
+        $battData,
+        $testUpowerInfos{$test}->{extractedData},
+        "$test: _getBatteryDataFromUpower()"
+    );
+}
+
+

--- a/t/tasks/inventory/generic/dmidecode/battery.t
+++ b/t/tasks/inventory/generic/dmidecode/battery.t
@@ -50,10 +50,16 @@ my %tests = (
     'windows-hyperV' => undef
 );
 
+my %testUpower = (
+    'enumerate_1.txt' => {
+        extractedName => '/org/freedesktop/UPower/devices/battery_BAT1'
+    }
+);
+
 plan tests =>
     (scalar keys %tests)               +
     (scalar grep { $_ } values %tests) +
-    1;
+    2;
 
 my $inventory = FusionInventory::Test::Inventory->new();
 
@@ -65,4 +71,12 @@ foreach my $test (keys %tests) {
     lives_ok {
         $inventory->addEntry(section => 'BATTERIES', entry => $battery);
     } "$test: registering";
+}
+
+foreach my $test (keys %testUpower) {
+    my $file = 'resources/generic/upower/' . $test;
+    my $battName =  FusionInventory::Agent::Task::Inventory::Generic::Dmidecode::Battery::_getBatteryNameFromUpower(
+        file => $file
+    );
+    ok ($battName eq $testUpower{$test}->{extractedName});
 }

--- a/t/tasks/inventory/generic/dmidecode/memory.t
+++ b/t/tasks/inventory/generic/dmidecode/memory.t
@@ -561,6 +561,17 @@ my %tests = (
             CAPACITY         => '512',
             MANUFACTURER     => undef,
             MEMORYCORRECTION => 'Single-bit ECC'
+        },
+        {
+            NUMSLOTS         => 3,
+            SERIALNUMBER     => undef,
+            DESCRIPTION      => 'DIMM',
+            SPEED            => '400 MHz (2.5 ns)',
+            TYPE             => 'DDR',
+            CAPTION          => 'DIMM 3',
+            CAPACITY         => '512',
+            MANUFACTURER     => undef,
+            MEMORYCORRECTION => 'Single-bit ECC'
         }
     ],
     'rhel-4.3' => [


### PR DESCRIPTION
First, data is retrieved from dmidecode, as usual. 
Then, if 'upower' available (like in Fedora), missing values are filled from this command.