### PR TITLE
Batteries (can be now in the plural, yeah !)

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/Generic/Batteries/Upower.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Generic/Batteries/Upower.pm
@@ -18,14 +18,13 @@ sub doInventory {
     my (%params) = @_;
 
     my $inventory = $params{inventory};
-    my $logger    = $params{logger};
 
     my @batteries = _getBatteriesFromUpower(%params);
 
     return unless @batteries;
 
     foreach my $batt (@batteries) {
-        $inventory->setBattery($batt);
+        $inventory->setBatteryUsingIndex($batt);
     }
 }
 

--- a/lib/FusionInventory/Agent/Task/Inventory/Generic/Batteries/Upower.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Generic/Batteries/Upower.pm
@@ -1,0 +1,98 @@
+package FusionInventory::Agent::Task::Inventory::Generic::Batteries::Upower;
+
+use strict;
+use warnings;
+
+use FusionInventory::Agent::Tools;
+use FusionInventory::Agent::Tools::Generic;
+
+my $command = 'upower';
+
+sub isEnabled {
+    my (%params) = @_;
+    return 0 if $params{no_category}->{battery};
+    return canRun($command);
+}
+
+sub doInventory {
+    my (%params) = @_;
+
+    my $inventory = $params{inventory};
+    my $logger    = $params{logger};
+
+    my @batteries = _getBatteriesFromUpower(%params);
+
+    return unless @batteries;
+
+    foreach my $batt (@batteries) {
+        $inventory->setBattery($batt);
+    }
+}
+
+sub _getBatteriesFromUpower {
+    my (%params) = @_;
+
+    return unless canRun($command);
+
+    my @batteriesName = _getBatteriesNameFromUpower(
+        %params,
+        command => $command . ' --enumerate'
+    );
+
+    return unless @batteriesName;
+
+    my @batteriesData = ();
+    foreach my $battName (@batteriesName) {
+        my $battData = _getBatteryDataFromUpower(
+            %params,
+            command => $command . ' -i ' . $battName
+        );
+        push @batteriesData, $battData
+    }
+
+    return @batteriesData;
+}
+
+sub _getBatteriesNameFromUpower {
+    my (%params) = @_;
+
+    my @lines = getAllLines(
+        %params
+    );
+
+    my @battName;
+    for my $line (@lines) {
+        if ($line =~ /^(.*\/battery_\S+)$/) {
+            push @battName, $1;
+        }
+    }
+
+    return @battName;
+}
+
+sub _getBatteryDataFromUpower {
+    my (%params) = @_;
+
+    my @lines = getAllLines(
+        %params
+    );
+
+    my $data = {};
+    for my $line (@lines) {
+        if ($line =~ /^\s*(\S+):\s*(\S+(?:\s+\S+)*)$/) {
+            $data->{$1} = $2;
+        }
+    }
+    my $battData = {
+        NAME => $data->{model} || '',
+        CAPACITY => $data->{'energy-full'},
+        VOLTAGE => $data->{voltage},
+        CHEMISTRY => $data->{technology},
+        SERIAL => $data->{serial},
+        MANUFACTURER => getCanonicalManufacturer($data->{vendor}) || getCanonicalManufacturer($data->{manufacturer}) || undef,
+    };
+
+    return $battData;
+}
+
+1;

--- a/lib/FusionInventory/Agent/Task/Inventory/Generic/Dmidecode/Battery.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Generic/Dmidecode/Battery.pm
@@ -110,7 +110,13 @@ sub _mergeBatteries {
         # if we have some data to identify the battery already in inventory
         if (scalar (keys %$fields) >  0) {
             $battInInventory = $inventory->getBattery($fields);
-        } else {
+        }
+        # dmidecode sometimes returns hexadecimal values for Serial number
+        if (! $battInInventory && $fields->{SERIAL}) {
+            $fields->{SERIAL} = hex2dec($fields->{SERIAL});
+            $battInInventory = $inventory->getBattery($fields);
+        }
+        unless ($battInInventory) {
             # looking if we are in this special context :
             # we have one battery in inventory
             # and we have one battery to merge

--- a/lib/FusionInventory/Agent/Tools.pm
+++ b/lib/FusionInventory/Agent/Tools.pm
@@ -111,18 +111,18 @@ sub getCanonicalManufacturer {
     if (exists $manufacturers{$manufacturer}) {
         $manufacturer = $manufacturers{$manufacturer};
     } elsif ($manufacturer =~ /(
-        maxtor    |
-        sony      |
-        compaq    |
-        ibm       |
-        toshiba   |
-        fujitsu   |
-        lg        |
-        samsung   |
-        nec       |
-        transcend |
-        matshita  |
-        hitachi   |
+        maxtor     |
+        sony       |
+        compaq     |
+        ibm        |
+        toshiba    |
+        fujitsu    |
+        lg(?:\s|$) |
+        samsung    |
+        nec        |
+        transcend  |
+        matshita   |
+        hitachi    |
         pioneer
     )/xi) {
         $manufacturer = ucfirst(lc($1));

--- a/resources/generic/batteries/upower/dmi_decode.txt
+++ b/resources/generic/batteries/upower/dmi_decode.txt
@@ -1,0 +1,20 @@
+Getting SMBIOS data from sysfs.
+SMBIOS 2.6 present.
+
+# Next 2 lines have been added in order to permit function to return the data
+Handle 0x0014, DMI type 1, 26 bytes
+    key: value
+
+Handle 0x0014, DMI type 22, 26 bytes
+Portable Battery
+	Location: 1st Battery
+	Manufacturer: TOSHIBA
+	Manufacture Date: **/**/****
+	Serial Number: 0000000000
+	Name:
+	Design Capacity: Unknown
+	Design Voltage: Unknown
+	SBDS Version: Not Specified
+	Maximum Error: Unknown
+	SBDS Chemistry: Li-ION
+	OEM-specific Information: 0x00000000

--- a/resources/generic/batteries/upower/dmidecode_2.txt
+++ b/resources/generic/batteries/upower/dmidecode_2.txt
@@ -1,0 +1,1073 @@
+# dmidecode 3.0
+Getting SMBIOS data from sysfs.
+SMBIOS 2.8 present.
+94 structures occupying 5732 bytes.
+Table at 0x000E0000.
+
+Handle 0x0000, DMI type 0, 24 bytes
+BIOS Information
+	Vendor: Dell Inc.
+	Version: 1.4.17
+	Release Date: 05/10/2017
+	Address: 0xF0000
+	Runtime Size: 64 kB
+	ROM Size: 16384 kB
+	Characteristics:
+		PCI is supported
+		PNP is supported
+		BIOS is upgradeable
+		BIOS shadowing is allowed
+		Boot from CD is supported
+		Selectable boot is supported
+		EDD is supported
+		5.25"/1.2 MB floppy services are supported (int 13h)
+		3.5"/720 kB floppy services are supported (int 13h)
+		3.5"/2.88 MB floppy services are supported (int 13h)
+		Print screen service is supported (int 5h)
+		8042 keyboard services are supported (int 9h)
+		Serial services are supported (int 14h)
+		Printer services are supported (int 17h)
+		ACPI is supported
+		USB legacy is supported
+		Smart battery is supported
+		BIOS boot specification is supported
+		Function key-initiated network boot is supported
+		Targeted content distribution is supported
+		UEFI is supported
+	BIOS Revision: 1.4
+
+Handle 0x0001, DMI type 1, 27 bytes
+System Information
+	Manufacturer: Dell Inc.
+	Product Name: XPS 13 9350
+	Version: Not Specified
+	Serial Number: D0JHP72
+	UUID: 4C4C4544-0030-4A10-8048-C4C04F503732
+	Wake-up Type: Power Switch
+	SKU Number: 0704
+	Family: NULL
+
+Handle 0x0002, DMI type 2, 15 bytes
+Base Board Information
+	Manufacturer: Dell Inc.
+	Product Name: 07TYC2
+	Version: A01
+	Serial Number: /D0JHP72/CN1296364600B8/
+	Asset Tag: Not Specified
+	Features:
+		Board is a hosting board
+		Board is replaceable
+	Location In Chassis: Not Specified
+	Chassis Handle: 0x0003
+	Type: Motherboard
+	Contained Object Handles: 0
+
+Handle 0x0003, DMI type 3, 22 bytes
+Chassis Information
+	Manufacturer: Dell Inc.
+	Type: Laptop
+	Lock: Not Present
+	Version: Not Specified
+	Serial Number: D0JHP72
+	Asset Tag: Not Specified
+	Boot-up State: Safe
+	Power Supply State: Safe
+	Thermal State: Safe
+	Security Status: None
+	OEM Information: 0x00000000
+	Height: Unspecified
+	Number Of Power Cords: 1
+	Contained Elements: 0
+	SKU Number: Laptop
+
+Handle 0x0004, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: JUSB1
+	Internal Connector Type: None
+	External Reference Designator: USB1
+	External Connector Type: Access Bus (USB)
+	Port Type: USB
+
+Handle 0x0005, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: JUSB2
+	Internal Connector Type: None
+	External Reference Designator: USB2
+	External Connector Type: Access Bus (USB)
+	Port Type: USB
+
+Handle 0x0006, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: JSD1
+	Internal Connector Type: None
+	External Reference Designator: Cardreader
+	External Connector Type: Other
+	Port Type: None
+
+Handle 0x0007, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: JHP1
+	Internal Connector Type: None
+	External Reference Designator: Audio Jack
+	External Connector Type: Mini Jack (headphones)
+	Port Type: Audio Port
+
+Handle 0x0008, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: JTypeC
+	Internal Connector Type: None
+	External Reference Designator: USB3
+	External Connector Type: Access Bus (USB)
+	Port Type: USB
+
+Handle 0x0009, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: JeDP1 - eDP
+	Internal Connector Type: None
+	External Reference Designator: Not Specified
+	External Connector Type: None
+	Port Type: Other
+
+Handle 0x000A, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: JNGFF1 - WLAN/BT/Wigig CONN
+	Internal Connector Type: None
+	External Reference Designator: Not Specified
+	External Connector Type: None
+	Port Type: Other
+
+Handle 0x000B, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: JNGFF2 - HDD
+	Internal Connector Type: None
+	External Reference Designator: Not Specified
+	External Connector Type: None
+	Port Type: Other
+
+Handle 0x000C, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: JKBTP1 - Keyboard
+	Internal Connector Type: None
+	External Reference Designator: Not Specified
+	External Connector Type: None
+	Port Type: Keyboard Port
+
+Handle 0x000D, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: JFAN1 - CPU FAN
+	Internal Connector Type: None
+	External Reference Designator: Not Specified
+	External Connector Type: None
+	Port Type: Other
+
+Handle 0x000E, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: JSPK1 - Speaker
+	Internal Connector Type: Mini Jack (headphones)
+	External Reference Designator: Not Specified
+	External Connector Type: None
+	Port Type: Audio Port
+
+Handle 0x000F, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: JXDP1 - CPU XDP Port
+	Internal Connector Type: None
+	External Reference Designator: Not Specified
+	External Connector Type: None
+	Port Type: Other
+
+Handle 0x0010, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: JAPS1 - Automatic Power
+	Internal Connector Type: None
+	External Reference Designator: Not Specified
+	External Connector Type: None
+	Port Type: Other
+
+Handle 0x0011, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: JLPDE1 - 80 PORT
+	Internal Connector Type: None
+	External Reference Designator: Not Specified
+	External Connector Type: None
+	Port Type: Other
+
+Handle 0x0012, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: JDEG1 - Debug PORT
+	Internal Connector Type: None
+	External Reference Designator: Not Specified
+	External Connector Type: None
+	Port Type: Other
+
+Handle 0x0013, DMI type 8, 9 bytes
+Port Connector Information
+	Internal Reference Designator: JRTC1 - RTC
+	Internal Connector Type: None
+	External Reference Designator: Not Specified
+	External Connector Type: None
+	Port Type: Other
+
+Handle 0x0014, DMI type 9, 17 bytes
+System Slot Information
+	Designation: J6B2
+	Type: x16 PCI Express
+	Current Usage: In Use
+	Length: Long
+	ID: 0
+	Characteristics:
+		3.3 V is provided
+		Opening is shared
+		PME signal is supported
+	Bus Address: 0000:00:01.0
+
+Handle 0x0015, DMI type 9, 17 bytes
+System Slot Information
+	Designation: J6B1
+	Type: x1 PCI Express
+	Current Usage: In Use
+	Length: Short
+	ID: 1
+	Characteristics:
+		3.3 V is provided
+		Opening is shared
+		PME signal is supported
+	Bus Address: 0000:00:1c.3
+
+Handle 0x0016, DMI type 9, 17 bytes
+System Slot Information
+	Designation: J6D1
+	Type: x1 PCI Express
+	Current Usage: In Use
+	Length: Short
+	ID: 2
+	Characteristics:
+		3.3 V is provided
+		Opening is shared
+		PME signal is supported
+	Bus Address: 0000:00:1c.4
+
+Handle 0x0017, DMI type 9, 17 bytes
+System Slot Information
+	Designation: J7B1
+	Type: x1 PCI Express
+	Current Usage: In Use
+	Length: Short
+	ID: 3
+	Characteristics:
+		3.3 V is provided
+		Opening is shared
+		PME signal is supported
+	Bus Address: 0000:00:1c.5
+
+Handle 0x0018, DMI type 9, 17 bytes
+System Slot Information
+	Designation: J8B4
+	Type: x1 PCI Express
+	Current Usage: In Use
+	Length: Short
+	ID: 4
+	Characteristics:
+		3.3 V is provided
+		Opening is shared
+		PME signal is supported
+	Bus Address: 0000:00:1c.6
+
+Handle 0x0019, DMI type 10, 6 bytes
+On Board Device Information
+	Type: Video
+	Status: Enabled
+	Description: "Intel HD Graphics"
+
+Handle 0x001A, DMI type 11, 5 bytes
+OEM Strings
+	String 1: Dell System
+	String 2: 1[0704]
+	String 3: 3[1.0]
+	String 4: 12[www.dell.com]
+	String 5: 14[1]
+	String 6: 15[0]
+
+Handle 0x001B, DMI type 12, 5 bytes
+System Configuration Options
+	Option 1: To Be Filled By O.E.M.
+
+Handle 0x001C, DMI type 15, 35 bytes
+System Event Log
+	Area Length: 4 bytes
+	Header Start Offset: 0x0000
+	Header Length: 2 bytes
+	Data Start Offset: 0x0002
+	Access Method: Indexed I/O, one 16-bit index port, one 8-bit data port
+	Access Address: Index 0x046A, Data 0x046C
+	Status: Invalid, Not Full
+	Change Token: 0x00000000
+	Header Format: No Header
+	Supported Log Type Descriptors: 6
+	Descriptor 1: End of log
+	Data Format 1: OEM-specific
+	Descriptor 2: End of log
+	Data Format 2: OEM-specific
+	Descriptor 3: End of log
+	Data Format 3: OEM-specific
+	Descriptor 4: End of log
+	Data Format 4: OEM-specific
+	Descriptor 5: End of log
+	Data Format 5: OEM-specific
+	Descriptor 6: End of log
+	Data Format 6: OEM-specific
+
+Handle 0x001D, DMI type 21, 7 bytes
+Built-in Pointing Device
+	Type: Touch Pad
+	Interface: Bus Mouse
+	Buttons: 2
+
+Handle 0x0022, DMI type 25, 9 bytes
+	System Power Controls
+	Next Scheduled Power-on: *-* 00:00:00
+
+Handle 0x0023, DMI type 32, 20 bytes
+System Boot Information
+	Status: No errors detected
+
+Handle 0x0024, DMI type 34, 11 bytes
+Management Device
+	Description: LM78-1
+	Type: LM78
+	Address: 0x00000000
+	Address Type: I/O Port
+
+Handle 0x0026, DMI type 36, 16 bytes
+Management Device Threshold Data
+	Lower Non-critical Threshold: 1
+	Upper Non-critical Threshold: 2
+	Lower Critical Threshold: 3
+	Upper Critical Threshold: 4
+	Lower Non-recoverable Threshold: 5
+	Upper Non-recoverable Threshold: 6
+
+Handle 0x0028, DMI type 36, 16 bytes
+Management Device Threshold Data
+	Lower Non-critical Threshold: 1
+	Upper Non-critical Threshold: 2
+	Lower Critical Threshold: 3
+	Upper Critical Threshold: 4
+	Lower Non-recoverable Threshold: 5
+	Upper Non-recoverable Threshold: 6
+
+Handle 0x002A, DMI type 36, 16 bytes
+Management Device Threshold Data
+
+Handle 0x0030, DMI type 41, 11 bytes
+Onboard Device
+	Reference Designation:  Onboard IGD
+	Type: Video
+	Status: Enabled
+	Type Instance: 1
+	Bus Address: 0000:00:02.0
+
+Handle 0x0031, DMI type 41, 11 bytes
+Onboard Device
+	Reference Designation:  Onboard LAN
+	Type: Ethernet
+	Status: Enabled
+	Type Instance: 1
+	Bus Address: 0000:00:19.0
+
+Handle 0x0032, DMI type 41, 11 bytes
+Onboard Device
+	Reference Designation:  Onboard 1394
+	Type: Other
+	Status: Enabled
+	Type Instance: 1
+	Bus Address: 0000:03:1c.2
+
+Handle 0x0033, DMI type 255, 8 bytes
+OEM-specific Type
+	Header and Data:
+		FF 08 33 00 01 02 00 00
+	Strings:
+		_SIDLLEwPLyhIgmg
+		0704
+		_SIDAvf90w7wKZiZ
+		DELL
+
+Handle 0x0034, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Not Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 64 kB
+	Maximum Size: 64 kB
+	Supported SRAM Types:
+		Synchronous
+	Installed SRAM Type: Synchronous
+	Speed: Unknown
+	Error Correction Type: Parity
+	System Type: Data
+	Associativity: 8-way Set-associative
+
+Handle 0x0035, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L1 Cache
+	Configuration: Enabled, Not Socketed, Level 1
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 64 kB
+	Maximum Size: 64 kB
+	Supported SRAM Types:
+		Synchronous
+	Installed SRAM Type: Synchronous
+	Speed: Unknown
+	Error Correction Type: Parity
+	System Type: Instruction
+	Associativity: 8-way Set-associative
+
+Handle 0x0036, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L2 Cache
+	Configuration: Enabled, Not Socketed, Level 2
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 512 kB
+	Maximum Size: 512 kB
+	Supported SRAM Types:
+		Synchronous
+	Installed SRAM Type: Synchronous
+	Speed: Unknown
+	Error Correction Type: Single-bit ECC
+	System Type: Unified
+	Associativity: 4-way Set-associative
+
+Handle 0x0037, DMI type 7, 19 bytes
+Cache Information
+	Socket Designation: L3 Cache
+	Configuration: Enabled, Not Socketed, Level 3
+	Operational Mode: Write Back
+	Location: Internal
+	Installed Size: 3072 kB
+	Maximum Size: 3072 kB
+	Supported SRAM Types:
+		Synchronous
+	Installed SRAM Type: Synchronous
+	Speed: Unknown
+	Error Correction Type: Multi-bit ECC
+	System Type: Unified
+	Associativity: 12-way Set-associative
+
+Handle 0x0038, DMI type 4, 48 bytes
+Processor Information
+	Socket Designation: U3E1
+	Type: Central Processor
+	Family: Core i5
+	Manufacturer: Intel(R) Corporation
+	ID: E3 06 04 00 FF FB EB BF
+	Signature: Type 0, Family 6, Model 78, Stepping 3
+	Flags:
+		FPU (Floating-point unit on-chip)
+		VME (Virtual mode extension)
+		DE (Debugging extension)
+		PSE (Page size extension)
+		TSC (Time stamp counter)
+		MSR (Model specific registers)
+		PAE (Physical address extension)
+		MCE (Machine check exception)
+		CX8 (CMPXCHG8 instruction supported)
+		APIC (On-chip APIC hardware supported)
+		SEP (Fast system call)
+		MTRR (Memory type range registers)
+		PGE (Page global enable)
+		MCA (Machine check architecture)
+		CMOV (Conditional move instruction supported)
+		PAT (Page attribute table)
+		PSE-36 (36-bit page size extension)
+		CLFSH (CLFLUSH instruction supported)
+		DS (Debug store)
+		ACPI (ACPI supported)
+		MMX (MMX technology supported)
+		FXSR (FXSAVE and FXSTOR instructions supported)
+		SSE (Streaming SIMD extensions)
+		SSE2 (Streaming SIMD extensions 2)
+		SS (Self-snoop)
+		HTT (Multi-threading)
+		TM (Thermal monitor supported)
+		PBE (Pending break enabled)
+	Version: Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz
+	Voltage: 0.8 V
+	External Clock: 100 MHz
+	Max Speed: 2300 MHz
+	Current Speed: 2300 MHz
+	Status: Populated, Enabled
+	Upgrade: Other
+	L1 Cache Handle: 0x0035
+	L2 Cache Handle: 0x0036
+	L3 Cache Handle: 0x0037
+	Serial Number: To Be Filled By O.E.M.
+	Asset Tag: To Be Filled By O.E.M.
+	Part Number: To Be Filled By O.E.M.
+	Core Count: 2
+	Thread Count: 4
+	Characteristics:
+		64-bit capable
+		Multi-Core
+		Hardware Thread
+		Execute Protection
+		Enhanced Virtualization
+		Power/Performance Control
+
+Handle 0x0039, DMI type 16, 23 bytes
+Physical Memory Array
+	Location: System Board Or Motherboard
+	Use: System Memory
+	Error Correction Type: None
+	Maximum Capacity: 16 GB
+	Error Information Handle: Not Provided
+	Number Of Devices: 2
+
+Handle 0x003A, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0039
+	Error Information Handle: Not Provided
+	Total Width: 64 bits
+	Data Width: 64 bits
+	Size: 4096 MB
+	Form Factor: Chip
+	Set: None
+	Locator: System Board Memory
+	Bank Locator: BANK 0
+	Type: LPDDR3
+	Type Detail: Synchronous
+	Speed: 1867 MHz
+	Manufacturer: Elpida
+	Serial Number: 12161217
+	Asset Tag: 9876543210
+	Part Number: EDFA232A2MA-JD-F-R
+	Rank: 2
+	Configured Clock Speed: 1867 MHz
+	Minimum Voltage: Unknown
+	Maximum Voltage: Unknown
+	Configured Voltage: 1.2 V
+
+Handle 0x003B, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x0039
+	Error Information Handle: Not Provided
+	Total Width: 64 bits
+	Data Width: 64 bits
+	Size: 4096 MB
+	Form Factor: Chip
+	Set: None
+	Locator: System Board Memory
+	Bank Locator: BANK 1
+	Type: LPDDR3
+	Type Detail: Synchronous
+	Speed: 1867 MHz
+	Manufacturer: Elpida
+	Serial Number: 12121212
+	Asset Tag: 9876543210
+	Part Number: EDFA232A2MA-JD-F-R
+	Rank: 2
+	Configured Clock Speed: 1867 MHz
+	Minimum Voltage: Unknown
+	Maximum Voltage: Unknown
+	Configured Voltage: 1.2 V
+
+Handle 0x003C, DMI type 19, 31 bytes
+Memory Array Mapped Address
+	Starting Address: 0x00000000000
+	Ending Address: 0x001FFFFFFFF
+	Range Size: 8 GB
+	Physical Array Handle: 0x0039
+	Partition Width: 2
+
+Handle 0x003D, DMI type 221, 12 bytes
+OEM-specific Type
+	Header and Data:
+		DD 0C 3D 00 01 01 00 01 08 00 00 00
+	Strings:
+		Reference Code - ACPI
+
+Handle 0x003E, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x00000000000
+	Ending Address: 0x000FFFFFFFF
+	Range Size: 4 GB
+	Physical Device Handle: 0x003A
+	Memory Array Mapped Address Handle: 0x003C
+	Partition Row Position: 1
+	Interleave Position: 1
+	Interleaved Data Depth: 1
+
+Handle 0x003F, DMI type 20, 35 bytes
+Memory Device Mapped Address
+	Starting Address: 0x00100000000
+	Ending Address: 0x001FFFFFFFF
+	Range Size: 4 GB
+	Physical Device Handle: 0x003B
+	Memory Array Mapped Address Handle: 0x003C
+	Partition Row Position: 1
+	Interleave Position: 2
+	Interleaved Data Depth: 1
+
+Handle 0x0300, DMI type 126, 22 bytes
+Inactive
+
+Handle 0x1600, DMI type 22, 26 bytes
+Portable Battery
+	Location: Sys. Battery Bay
+	Manufacturer: SMP
+	Manufacture Date: 11/10/2015
+	Serial Number: 0E62
+	Name: DELL JHXPY53
+	Design Capacity: 57530 mWh
+	Design Voltage: 7600 mV
+	SBDS Version: 1.0
+	Maximum Error: 6%
+	SBDS Chemistry: LiP
+	OEM-specific Information: 0x00000801
+
+Handle 0x1B00, DMI type 27, 15 bytes
+Cooling Device
+	Temperature Probe Handle: 0x1C00
+	Type: Chip Fan
+	Status: OK
+	OEM-specific Information: 0x0000DD00
+	Nominal Speed: 6000 rpm
+	Description: CPU Fan
+
+Handle 0x1C00, DMI type 28, 22 bytes
+Temperature Probe
+	Description: CPU Probe
+	Location: Motherboard
+	Status: OK
+	Maximum Value: 127.0 deg C
+	Minimum Value: -127.0 deg C
+	Resolution: 1.000 deg C
+	Tolerance: Unknown
+	Accuracy: Unknown
+	OEM-specific Information: 0x0000DC00
+	Nominal Value: 10.0 deg C
+
+Handle 0x1C01, DMI type 28, 22 bytes
+Temperature Probe
+	Description: True Ambient
+	Location: Motherboard
+	Status: OK
+	Maximum Value: 127.0 deg C
+	Minimum Value: -127.0 deg C
+	Resolution: 1.000 deg C
+	Tolerance: Unknown
+	Accuracy: Unknown
+	OEM-specific Information: 0x0000DC01
+	Nominal Value: 10.0 deg C
+
+Handle 0x1C02, DMI type 28, 22 bytes
+Temperature Probe
+	Description: Memory Module
+	Location: Motherboard
+	Status: OK
+	Maximum Value: 127.0 deg C
+	Minimum Value: -127.0 deg C
+	Resolution: 1.000 deg C
+	Tolerance: Unknown
+	Accuracy: Unknown
+	OEM-specific Information: 0x0000DC02
+	Nominal Value: 10.0 deg C
+
+Handle 0x1C03, DMI type 28, 22 bytes
+Temperature Probe
+	Description: Other Probe
+	Location: Processor
+	Status: OK
+	Maximum Value: 127.0 deg C
+	Minimum Value: -127.0 deg C
+	Resolution: 1.000 deg C
+	Tolerance: Unknown
+	Accuracy: Unknown
+	OEM-specific Information: 0x0000DC03
+	Nominal Value: 10.0 deg C
+
+Handle 0xB100, DMI type 177, 12 bytes
+OEM-specific Type
+	Header and Data:
+		B1 0C 00 B1 1A 00 00 00 00 00 00 00
+
+Handle 0xB200, DMI type 178, 84 bytes
+OEM-specific Type
+	Header and Data:
+		B2 54 00 B2 3D 00 0C 00 3C 00 0A 00 3B 00 0B 00
+		0A 01 12 00 52 00 20 00 42 00 18 00 58 00 14 00
+		57 00 13 00 10 00 FF 00 11 00 FF 00 12 00 FF 00
+		13 00 FF 00 14 00 FF 00 1E 00 FF 00 1F 00 FF 00
+		20 00 FF 00 21 00 FF 00 22 00 FF 00 50 01 26 00
+		44 00 16 00
+	Strings:
+		                                        
+
+Handle 0xD000, DMI type 208, 16 bytes
+OEM-specific Type
+	Header and Data:
+		D0 10 00 D0 03 0A FE 00 04 07 01 02 00 00 00 00
+	Strings:
+		20160406
+		20160421
+
+Handle 0xD100, DMI type 209, 12 bytes
+OEM-specific Type
+	Header and Data:
+		D1 0C 00 D1 78 03 07 03 04 0F 80 03
+
+Handle 0xD200, DMI type 210, 12 bytes
+OEM-specific Type
+	Header and Data:
+		D2 0C 00 D2 00 00 00 03 06 80 04 03
+
+Handle 0xD800, DMI type 216, 9 bytes
+OEM-specific Type
+	Header and Data:
+		D8 09 00 D8 01 02 01 88 00
+	Strings:
+		"Intel Corp."
+		"2089"
+
+Handle 0xD900, DMI type 217, 8 bytes
+OEM-specific Type
+	Header and Data:
+		D9 08 00 D9 01 02 01 03
+	Strings:
+		US-101
+		Proprietary
+
+Handle 0xDA00, DMI type 218, 251 bytes
+OEM-specific Type
+	Header and Data:
+		DA FB 00 DA B2 00 04 FF 1F B6 40 05 00 05 00 03
+		00 06 00 06 00 05 00 0B 00 0B 00 01 00 0C 00 0C
+		00 02 00 0D 00 0D 00 03 00 0F 00 0F 00 00 00 11
+		00 11 00 02 00 12 00 12 00 04 00 1E 00 1E 00 00
+		00 22 00 22 00 01 00 23 00 23 00 00 00 28 00 28
+		00 00 00 29 00 29 00 01 00 2A 00 2A 00 02 00 2B
+		00 2B 00 FF FF 2C 00 2C 00 FF FF 40 00 40 00 01
+		00 41 00 41 00 00 00 42 00 42 00 01 00 43 00 43
+		00 00 00 50 00 50 00 01 00 55 00 55 00 00 00 5C
+		00 5C 00 01 00 5D 00 5D 00 00 00 65 00 65 00 00
+		00 66 00 66 00 01 00 7D 00 7D 00 FF FF 93 00 93
+		00 01 00 94 00 94 00 00 00 9B 00 9B 00 01 00 9C
+		00 9C 00 00 00 9F 00 9F 00 00 00 A0 00 A0 00 01
+		00 A1 00 A1 00 00 00 A3 00 A3 00 01 00 D1 00 D1
+		00 01 00 D2 00 D2 00 00 00 EA 00 EA 00 00 00 EB
+		00 EB 00 01 00 FF FF FF FF 00 00
+
+Handle 0xDA01, DMI type 218, 251 bytes
+OEM-specific Type
+	Header and Data:
+		DA FB 01 DA B2 00 04 FF 1F B6 40 EC 00 EC 00 02
+		00 ED 00 ED 00 00 00 F0 00 F0 00 01 00 F1 00 F1
+		00 00 00 F2 00 F2 00 01 00 F3 00 F3 00 02 00 09
+		01 09 01 00 00 0E 01 0E 01 01 00 0F 01 0F 01 00
+		00 10 01 10 01 01 00 11 01 11 01 00 00 1B 01 1B
+		01 00 00 1C 01 1C 01 01 00 2B 01 2B 01 01 00 2C
+		01 2C 01 00 00 2D 01 2D 01 01 00 2E 01 2E 01 00
+		00 35 01 35 01 FF 00 38 01 38 01 01 00 39 01 39
+		01 02 00 40 01 40 01 00 00 41 01 41 01 01 00 46
+		01 46 01 00 00 47 01 47 01 01 00 4A 01 4A 01 00
+		00 4B 01 4B 01 01 00 4C 01 4C 01 01 00 4D 01 4D
+		01 00 00 52 01 52 01 01 00 53 01 53 01 00 00 75
+		01 75 01 02 00 76 01 76 01 01 00 7F 01 7F 01 00
+		00 80 01 80 01 01 00 81 01 81 01 00 00 82 01 82
+		01 01 00 89 01 89 01 00 00 8A 01 8A 01 01 00 93
+		01 93 01 00 00 FF FF FF FF 00 00
+
+Handle 0xDA02, DMI type 218, 251 bytes
+OEM-specific Type
+	Header and Data:
+		DA FB 02 DA B2 00 04 FF 1F B6 40 94 01 94 01 01
+		00 9B 01 9B 01 00 00 9C 01 9C 01 01 00 DE 01 DE
+		01 00 00 DF 01 DF 01 01 00 E1 01 E1 01 00 00 EA
+		01 EA 01 00 00 EB 01 EB 01 01 00 02 02 02 02 00
+		00 03 02 03 02 01 00 04 02 04 02 00 00 05 02 05
+		02 01 00 16 02 16 02 06 00 2D 02 2D 02 01 00 2E
+		02 2E 02 00 00 32 02 32 02 02 00 33 02 33 02 01
+		00 35 02 35 02 01 00 36 02 36 02 00 00 4B 02 4B
+		02 01 00 4C 02 4C 02 00 00 64 02 64 02 01 00 65
+		02 65 02 00 00 66 02 66 02 01 00 67 02 67 02 00
+		00 68 02 68 02 01 00 69 02 69 02 00 00 6C 02 6C
+		02 01 00 6D 02 6D 02 00 00 6E 02 6E 02 00 00 85
+		02 85 02 01 00 86 02 86 02 00 00 94 02 94 02 01
+		00 95 02 95 02 00 00 A7 02 A7 02 01 00 A8 02 A8
+		02 00 00 B9 02 B9 02 01 00 BA 02 BA 02 00 00 BD
+		02 BD 02 01 00 FF FF FF FF 00 00
+
+Handle 0xDA03, DMI type 218, 251 bytes
+OEM-specific Type
+	Header and Data:
+		DA FB 03 DA B2 00 04 FF 1F B6 40 BE 02 BE 02 00
+		00 CD 02 CD 02 01 00 D8 02 D8 02 FF FF D9 02 D9
+		02 FF FF DA 02 DA 02 FF FF DB 02 DB 02 FF FF DC
+		02 DC 02 FF FF DD 02 DD 02 FF FF DE 02 DE 02 FF
+		FF DF 02 DF 02 FF FF E3 02 E3 02 01 00 E4 02 E4
+		02 00 00 E5 02 E5 02 01 00 EB 02 EB 02 06 00 ED
+		02 ED 02 01 00 EE 02 EE 02 00 00 F6 02 F6 02 08
+		00 12 03 12 03 03 00 13 03 13 03 01 00 14 03 14
+		03 00 00 15 03 15 03 01 00 16 03 16 03 00 00 17
+		03 17 03 01 00 18 03 18 03 00 00 19 03 19 03 01
+		00 1A 03 1A 03 00 00 1B 03 1B 03 01 00 1C 03 1C
+		03 00 00 1D 03 1D 03 01 00 1E 03 1E 03 00 00 1F
+		03 1F 03 01 00 20 03 20 03 00 00 25 03 25 03 01
+		00 26 03 26 03 01 00 29 03 29 03 01 00 2A 03 2A
+		03 00 00 2B 03 2B 03 01 00 2C 03 2C 03 00 00 38
+		03 38 03 01 00 FF FF FF FF 00 00
+
+Handle 0xDA04, DMI type 218, 251 bytes
+OEM-specific Type
+	Header and Data:
+		DA FB 04 DA B2 00 04 FF 1F B6 40 39 03 39 03 01
+		00 41 03 41 03 03 00 42 03 42 03 04 00 43 03 43
+		03 05 00 46 03 46 03 01 00 47 03 47 03 02 00 48
+		03 48 03 05 00 49 03 49 03 FF FF 4A 03 4A 03 FF
+		FF 4D 03 4D 03 01 00 4E 03 4E 03 00 00 4F 03 4F
+		03 01 00 50 03 50 03 00 00 57 03 57 03 00 00 58
+		03 58 03 01 00 61 03 61 03 01 00 62 03 62 03 00
+		00 64 03 64 03 01 00 65 03 65 03 00 00 66 03 66
+		03 00 00 67 03 67 03 01 00 69 03 69 03 00 00 6A
+		03 6A 03 01 00 6B 03 6B 03 02 00 6C 03 6C 03 00
+		00 6D 03 6D 03 01 00 6E 03 6E 03 FF FF 74 03 74
+		03 00 00 75 03 75 03 01 00 78 03 78 03 01 00 79
+		03 79 03 00 00 99 03 99 03 01 00 9A 03 9A 03 00
+		00 A2 03 A2 03 01 00 A3 03 A3 03 00 00 A6 03 A6
+		03 01 00 A7 03 A7 03 00 00 BE 03 BE 03 FF FF C1
+		03 C1 03 02 00 FF FF FF FF 00 00
+
+Handle 0xDA05, DMI type 218, 251 bytes
+OEM-specific Type
+	Header and Data:
+		DA FB 05 DA B2 00 04 FF 1F B6 40 C2 03 C2 03 03
+		00 C3 03 C3 03 04 00 C5 03 C5 03 01 00 C6 03 C6
+		03 00 00 C7 03 C7 03 01 00 C8 03 C8 03 02 00 C9
+		03 C9 03 01 00 CA 03 CA 03 00 00 CB 03 CB 03 FF
+		FF D3 03 D3 03 FF FF D4 03 D4 03 01 00 D5 03 D5
+		03 00 00 D6 03 D6 03 01 00 D7 03 D7 03 00 00 F6
+		03 F6 03 01 00 F7 03 F7 03 00 00 FE 03 FE 03 01
+		00 FF 03 FF 03 00 00 01 04 01 04 01 00 02 04 02
+		04 00 00 03 04 03 04 01 00 04 04 04 04 00 00 1E
+		04 1E 04 01 00 1F 04 1F 04 00 00 20 04 20 04 FF
+		FF 2B 04 2B 04 FF FF 31 04 31 04 FF FF 32 04 32
+		04 01 00 33 04 33 04 00 00 38 04 38 04 01 00 39
+		04 39 04 00 00 3A 04 3A 04 01 00 3B 04 3B 04 00
+		00 40 04 40 04 01 00 41 04 41 04 00 00 42 04 42
+		04 01 00 43 04 43 04 00 00 44 04 44 04 01 00 45
+		04 45 04 00 00 FF FF FF FF 00 00
+
+Handle 0xDA06, DMI type 218, 131 bytes
+OEM-specific Type
+	Header and Data:
+		DA 83 06 DA B2 00 04 FF 1F B6 40 46 04 46 04 01
+		00 47 04 47 04 00 00 51 04 51 04 FF FF 52 04 52
+		04 FF FF 61 04 61 04 01 00 62 04 62 04 00 00 85
+		04 85 04 01 00 86 04 86 04 00 00 9E 04 9E 04 01
+		00 9F 04 9F 04 00 00 A0 04 A0 04 01 00 A1 04 A1
+		04 00 00 A2 04 A2 04 01 00 A3 04 A3 04 00 00 4A
+		40 4A 40 01 00 4B 40 4B 40 00 00 0D 80 0D 80 00
+		00 0E 80 0E 80 01 00 0F 80 0F 80 00 02 FF FF FF
+		FF 00 00
+
+Handle 0xDA07, DMI type 218, 77 bytes
+OEM-specific Type
+	Header and Data:
+		DA 4D 07 DA B2 00 04 FF 1F B6 40 00 F1 00 F1 01
+		00 02 F1 02 F1 01 00 10 F1 10 F1 01 00 12 F1 12
+		F1 01 00 20 F1 20 F1 01 00 22 F1 22 F1 01 00 30
+		F1 30 F1 01 00 32 F1 32 F1 01 00 00 F6 00 F6 01
+		00 01 F6 01 F6 01 00 FF FF FF FF 00 00
+
+Handle 0xDA08, DMI type 218, 29 bytes
+OEM-specific Type
+	Header and Data:
+		DA 1D 08 DA B2 00 04 FF 1F B6 40 D7 03 3A 05 00
+		00 D6 03 3A 05 01 00 FF FF FF FF 00 00
+
+Handle 0xDC00, DMI type 220, 22 bytes
+OEM-specific Type
+	Header and Data:
+		DC 16 00 DC 00 F1 00 00 02 F1 00 00 00 00 00 00
+		00 00 00 00 00 00
+
+Handle 0xDC01, DMI type 220, 22 bytes
+OEM-specific Type
+	Header and Data:
+		DC 16 01 DC 10 F1 00 00 12 F1 00 00 00 00 00 00
+		00 00 00 00 00 00
+
+Handle 0xDC02, DMI type 220, 22 bytes
+OEM-specific Type
+	Header and Data:
+		DC 16 02 DC 20 F1 00 00 22 F1 00 00 00 00 00 00
+		00 00 00 00 00 00
+
+Handle 0xDC03, DMI type 220, 22 bytes
+OEM-specific Type
+	Header and Data:
+		DC 16 03 DC 30 F1 00 00 32 F1 00 00 00 00 00 00
+		00 00 00 00 00 00
+
+Handle 0xDD00, DMI type 221, 19 bytes
+OEM-specific Type
+	Header and Data:
+		DD 13 00 DD 02 01 00 00 F6 01 F6 00 00 00 00 00
+		00 00 00
+
+Handle 0xDE00, DMI type 222, 16 bytes
+OEM-specific Type
+	Header and Data:
+		DE 10 00 DE 01 04 00 00 17 07 03 09 36 01 00 00
+
+Handle 0xF028, DMI type 130, 20 bytes
+OEM-specific Type
+	Header and Data:
+		82 14 28 F0 24 41 4D 54 00 00 00 00 00 A5 AF 02
+		C0 00 00 00
+
+Handle 0xF029, DMI type 131, 64 bytes
+OEM-specific Type
+	Header and Data:
+		83 40 29 F0 31 00 00 00 0B 00 00 00 00 00 08 00
+		F8 00 48 9D 00 00 00 00 01 00 00 00 00 00 0B 00
+		B8 0B 1A 00 00 00 00 00 FE 00 FF FF 00 00 00 00
+		00 00 00 00 22 00 00 00 76 50 72 6F 00 00 00 00
+
+Handle 0xF02A, DMI type 221, 26 bytes
+OEM-specific Type
+	Header and Data:
+		DD 1A 2A F0 03 01 00 01 08 00 00 00 02 00 00 00
+		00 9E 00 03 00 00 05 00 00 00
+	Strings:
+		Reference Code - CPU
+		uCode Version
+		TXT ACM version
+
+Handle 0xF02B, DMI type 221, 26 bytes
+OEM-specific Type
+	Header and Data:
+		DD 1A 2B F0 03 01 00 01 08 00 00 00 02 00 0B 00
+		00 08 00 03 04 0B 00 1A B8 0B
+	Strings:
+		Reference Code - ME 11.0
+		MEBx version
+		ME Firmware Version
+		Consumer SKU
+
+Handle 0xF02C, DMI type 221, 68 bytes
+OEM-specific Type
+	Header and Data:
+		DD 44 2C F0 09 01 00 01 08 00 00 00 02 03 FF FF
+		FF FF FF 04 00 FF FF FF 21 00 05 00 FF FF FF 21
+		00 06 00 FF FF FF FF FF 07 00 3E 00 00 00 00 08
+		00 34 00 00 00 00 09 00 3E 00 00 00 00 0A 00 34
+		00 00 00 00
+	Strings:
+		Reference Code - SKL PCH
+		PCH-CRID Status
+		Disabled
+		PCH-CRID Original Value
+		PCH-CRID New Value
+		OPROM - RST - RAID
+		SKL PCH H Bx Hsio Version
+		SKL PCH H Dx Hsio Version
+		SKL PCH LP Bx Hsio Version
+		SKL PCH LP Cx Hsio Version
+
+Handle 0xF02D, DMI type 221, 54 bytes
+OEM-specific Type
+	Header and Data:
+		DD 36 2D F0 07 01 00 01 08 00 00 00 02 00 01 08
+		00 01 00 03 00 01 08 00 00 00 04 05 FF FF FF FF
+		FF 06 00 FF FF FF 08 00 07 00 FF FF FF 08 00 08
+		00 FF FF FF FF FF
+	Strings:
+		Reference Code - SA - System Agent
+		Reference Code - MRC
+		SA - PCIe Version
+		SA-CRID Status
+		Disabled
+		SA-CRID Original Value
+		SA-CRID New Value
+		OPROM - VBIOS
+
+Handle 0xF02E, DMI type 221, 96 bytes
+OEM-specific Type
+	Header and Data:
+		DD 60 2E F0 0D 01 00 00 00 00 00 00 02 00 FF FF
+		FF FF FF 03 04 FF FF FF FF FF 05 06 FF FF FF FF
+		FF 07 08 FF FF FF FF FF 09 00 00 00 00 00 00 0A
+		00 FF FF FF FF FF 0B 00 FF FF 00 00 00 0C 00 00
+		09 00 42 10 0D 00 02 00 00 00 00 0E 00 FF FF FF
+		FF FF 0F 00 FF FF FF FF FF 10 11 01 02 02 03 00
+	Strings:
+		Lan Phy Version
+		Sensor Firmware Version
+		Debug Mode Status
+		Enabled 
+		Performance Mode Status
+		Disabled
+		Debug Use USB(Disabled:Serial)
+		Disabled
+		ICC Overclocking Version
+		UNDI Version
+		EC FW Version
+		GOP Version
+		BIOS Guard Version
+		Base EC FW Version
+		EC-EC Protocol Version
+		Royal Park Version
+		BP1.2.2.0_RP03
+
+Handle 0xF03C, DMI type 136, 6 bytes
+OEM-specific Type
+	Header and Data:
+		88 06 3C F0 00 00
+
+Handle 0xF03D, DMI type 14, 26 bytes
+Group Associations
+	Name: Firmware Version Info
+	Items: 7
+		0x003D (<OUT OF SPEC>)
+		0xDD00 (<OUT OF SPEC>)
+		0xF02A (<OUT OF SPEC>)
+		0xF02B (<OUT OF SPEC>)
+		0xF02C (<OUT OF SPEC>)
+		0xF02D (<OUT OF SPEC>)
+		0xF02E (<OUT OF SPEC>)
+
+Handle 0xF03E, DMI type 14, 8 bytes
+Group Associations
+	Name: $MEI
+	Items: 1
+		0x0000 (<OUT OF SPEC>)
+
+Handle 0xF03F, DMI type 219, 81 bytes
+OEM-specific Type
+	Header and Data:
+		DB 51 3F F0 01 03 01 45 02 00 A0 06 03 00 60 20
+		00 00 00 00 40 08 00 01 1F 00 00 C9 0B C0 47 02
+		FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF
+		FF FF FF FF FF FF FF FF 03 00 00 00 80 00 00 00
+		00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+		00
+	Strings:
+		MEI1
+		MEI2
+		MEI3
+
+Handle 0xF040, DMI type 13, 22 bytes
+BIOS Language Information
+	Language Description Format: Long
+	Installable Languages: 2
+		en|US|iso8859-1
+		<BAD INDEX>
+	Currently Installed Language: en|US|iso8859-1
+
+Handle 0xF041, DMI type 127, 4 bytes
+End Of Table
+

--- a/resources/generic/batteries/upower/enumerate_1.txt
+++ b/resources/generic/batteries/upower/enumerate_1.txt
@@ -1,0 +1,4 @@
+/org/freedesktop/UPower/devices/line_power_ADP1
+/org/freedesktop/UPower/devices/battery_BAT1
+/org/freedesktop/UPower/devices/mouse_0003o046Do1017x0006
+/org/freedesktop/UPower/devices/DisplayDevice

--- a/resources/generic/batteries/upower/infos_1.txt
+++ b/resources/generic/batteries/upower/infos_1.txt
@@ -1,0 +1,22 @@
+native-path:          BAT1
+  model:                G71C000G7210
+  serial:               0
+  power supply:         yes
+  updated:              mar. 21 févr. 2017 10:20:29 CET (1 seconds ago)
+  has history:          yes
+  has statistics:       yes
+  battery
+    present:             yes
+    rechargeable:        yes
+    state:               fully-charged
+    warning-level:       none
+    energy:              39,264 Wh
+    energy-empty:        0 Wh
+    energy-full:         39,264 Wh
+    energy-full-design:  51,504 Wh
+    energy-rate:         0 W
+    voltage:             14,8 V
+    percentage:          100%
+    capacity:            76,2349%
+    technology:          lithium-ion
+    icon-name:          'battery-full-charged-symbolic'

--- a/resources/generic/batteries/upower/upower_enumerate_2.txt
+++ b/resources/generic/batteries/upower/upower_enumerate_2.txt
@@ -1,0 +1,3 @@
+/org/freedesktop/UPower/devices/line_power_AC
+/org/freedesktop/UPower/devices/battery_BAT0
+/org/freedesktop/UPower/devices/DisplayDevice

--- a/resources/generic/batteries/upower/upower_info_2.txt
+++ b/resources/generic/batteries/upower/upower_info_2.txt
@@ -1,0 +1,24 @@
+  native-path:          BAT0
+  vendor:               SMP
+  model:                DELL JHXPY53
+  serial:               3682
+  power supply:         yes
+  updated:              mar. 04 juil. 2017 09:15:35 CEST (88 seconds ago)
+  has history:          yes
+  has statistics:       yes
+  battery
+    present:             yes
+    rechargeable:        yes
+    state:               charging
+    warning-level:       none
+    energy:              47,3708 Wh
+    energy-empty:        0 Wh
+    energy-full:         53,4052 Wh
+    energy-full-design:  57,532 Wh
+    energy-rate:         0,194979 W
+    voltage:             8,541 V
+    percentage:          88%
+    capacity:            92,8269%
+    technology:          lithium-polymer
+    icon-name:          'battery-full-charging-symbolic'
+

--- a/t/agent/inventory.t
+++ b/t/agent/inventory.t
@@ -13,7 +13,7 @@ use FusionInventory::Agent;
 use FusionInventory::Agent::Logger;
 use FusionInventory::Agent::Inventory;
 
-plan tests => 26;
+plan tests => 29;
 
 my $logger = FusionInventory::Agent::Logger->new(
     backends  => [ 'Test' ],
@@ -355,3 +355,61 @@ is(
     undef,
     'operatingsystem section merge not supported field'
 );
+
+my $inventorySample = FusionInventory::Agent::Inventory->new();
+$inventorySample->{content}->{section1} = [
+    {
+        field1 => 'v1.1',
+        field2 => 'v1.2',
+        field3 => 'v1.3',
+    },
+    {
+        field1 => 'v2.1',
+        field2 => 'v2.2',
+        field3 => 'v2.3',
+    },
+];
+
+$inventorySample->{content}->{section2} = [
+    {
+        field1 => 'v1.1',
+        field2 => 'v1.2',
+        field3 => 'v1.3',
+    },
+    {
+        field1 => 'v2.1',
+        field2 => 'v2.2',
+        field3 => 'v2.3',
+    },
+];
+
+ok (FusionInventory::Agent::Inventory::_isKeyValueListInHash(
+    $inventorySample->{content}->{section2}->[0],
+    {
+        field3 => 'v1.3'
+    }
+));
+
+my $indexElement = $inventorySample->retrieveElementIndexInSection(
+    'section2',
+    {
+        field3 => 'v1.3'
+    }
+);
+ok (
+    defined $indexElement && $indexElement == 0,
+    "test retrieveElementIndexInSection()"
+);
+
+my $extractedElement = $inventorySample->retrieveElementInSection(
+    'section2',
+    {
+        field3 => 'v1.3'
+    }
+);
+cmp_deeply (
+    $extractedElement,
+    $inventorySample->{content}->{section2}->[0],
+    "test retrieveElementInSection()"
+);
+

--- a/t/tasks/inventory/generic/batteries/upower.t
+++ b/t/tasks/inventory/generic/batteries/upower.t
@@ -1,0 +1,61 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+use Test::Deep;
+use Test::More;
+use Test::NoWarnings;
+
+use FusionInventory::Agent::Task::Inventory::Generic::Batteries::Upower;
+
+my %testUpowerEnumerate = (
+    'enumerate_1.txt' => {
+        extractedNames     => [
+            '/org/freedesktop/UPower/devices/battery_BAT1'
+        ]
+    }
+);
+
+my %testUpowerInfos = (
+    'infos_1.txt' => {
+        extractedData => {
+            NAME         => 'G71C000G7210',
+            CAPACITY     => '39,264 Wh',
+            VOLTAGE      => '14,8 V',
+            CHEMISTRY    => 'lithium-ion',
+            SERIAL       => 0,
+            MANUFACTURER => undef
+        }
+    }
+);
+
+plan tests =>
+    scalar (keys %testUpowerEnumerate) +
+    scalar (keys %testUpowerInfos) +
+    1;
+
+foreach my $test (keys %testUpowerEnumerate) {
+    my $file = 'resources/generic/batteries/upower/'.$test;
+    my @battNames = FusionInventory::Agent::Task::Inventory::Generic::Batteries::Upower::_getBatteriesNameFromUpower(
+        file => $file
+    );
+    my @sortedExpected = sort { $a cmp $b } @{$testUpowerEnumerate{$test}->{extractedNames}};
+    my @sortedBattNames = sort { $a cmp $b } @battNames;
+    cmp_deeply (
+        \@sortedBattNames,
+        \@sortedExpected,
+        "$test: _getBatteriesNameFromUpower()"
+    );
+}
+
+foreach my $test (keys %testUpowerInfos) {
+    my $file = 'resources/generic/batteries/upower/' . $test;
+    my $battData = FusionInventory::Agent::Task::Inventory::Generic::Batteries::Upower::_getBatteryDataFromUpower(
+        file => $file
+    );
+    cmp_deeply(
+        $battData,
+        $testUpowerInfos{$test}->{extractedData},
+        "$test: _getBatteriesDataFromUpower()"
+    )
+}

--- a/t/tasks/inventory/generic/batteries/upower.t
+++ b/t/tasks/inventory/generic/batteries/upower.t
@@ -26,6 +26,16 @@ my %testUpowerInfos = (
             SERIAL       => 0,
             MANUFACTURER => undef
         }
+    },
+    'upower_info_2.txt' => {
+        extractedData => {
+            NAME         => 'DELL JHXPY53',
+            CAPACITY     => '53,4052 Wh',
+            VOLTAGE      => '8,541 V',
+            CHEMISTRY    => 'lithium-polymer',
+            SERIAL       => 3682,
+            MANUFACTURER => 'SMP'
+        }
     }
 );
 

--- a/t/tasks/inventory/generic/dmidecode/battery.t
+++ b/t/tasks/inventory/generic/dmidecode/battery.t
@@ -77,6 +77,26 @@ my %testUpowerMerged = (
                 DATE         => undef
             }
         ]
+    },
+    'upower_info_2.txt' => {
+        files => {
+            dmidecode => 'dmidecode_2.txt',
+            upowerInfos => {
+                '/org/freedesktop/UPower/devices/battery_BAT0' => 'upower_info_2.txt',
+            },
+            upowerNames => 'upower_enumerate_2.txt'
+        },
+        mergedData => [
+            {
+                NAME         => 'DELL JHXPY53',
+                CAPACITY     => '53,4052 Wh',
+                VOLTAGE      => '8,541 V',
+                CHEMISTRY    => 'lithium-polymer',
+                SERIAL       => 3682,
+                MANUFACTURER => 'SMP',
+                DATE         => '11/10/2015'
+            }
+        ]
     }
 );
 

--- a/t/tasks/inventory/generic/dmidecode/battery.t
+++ b/t/tasks/inventory/generic/dmidecode/battery.t
@@ -94,7 +94,7 @@ my %testUpowerMerged = (
                 CHEMISTRY    => 'lithium-polymer',
                 SERIAL       => 3682,
                 MANUFACTURER => 'SMP',
-                DATE         => '11/10/2015'
+                DATE         => '10/11/2015'
             }
         ]
     }

--- a/t/tasks/inventory/generic/dmidecode/battery.t
+++ b/t/tasks/inventory/generic/dmidecode/battery.t
@@ -11,58 +11,133 @@ use Test::NoWarnings;
 
 use FusionInventory::Test::Inventory;
 use FusionInventory::Agent::Task::Inventory::Generic::Dmidecode::Battery;
+use FusionInventory::Agent::Task::Inventory::Generic::Batteries::Upower;
 
 my %tests = (
     'freebsd-6.2' => undef,
-    'freebsd-8.1' => {
-        NAME         => 'EV06047',
-        SERIAL       => '61E6',
-        MANUFACTURER => 'LGC-LGC',
-        CHEMISTRY    => 'Lithium Ion',
-        VOLTAGE      => 10800,
-        CAPACITY     => 4400,
-        DATE         => '15/01/2010'
-    },
-    'linux-2.6' => {
-        NAME         => 'DELL C129563',
-        MANUFACTURER => 'Samsung SDI',
-        SERIAL       => '7734',
-        CHEMISTRY    => 'LION',
-        VOLTAGE      => 11100,
-        CAPACITY     => 48000,
-        DATE         => '11/03/2006'
-    },
+    'freebsd-8.1' => [
+        {
+            NAME         => 'EV06047',
+            SERIAL       => '61E6',
+            MANUFACTURER => 'LGC-LGC',
+            CHEMISTRY    => 'Lithium Ion',
+            VOLTAGE      => 10800,
+            CAPACITY     => 4400,
+            DATE         => '15/01/2010'
+        }
+    ],
+    'linux-2.6' => [
+        {
+            NAME         => 'DELL C129563',
+            MANUFACTURER => 'Samsung',
+            SERIAL       => '7734',
+            CHEMISTRY    => 'LION',
+            VOLTAGE      => 11100,
+            CAPACITY     => 48000,
+            DATE         => '11/03/2006'
+        }
+    ],
     'openbsd-3.7' => undef,
     'openbsd-3.8' => undef,
     'rhel-2.1' => undef,
     'rhel-3.4' => undef,
     'rhel-4.3' => undef,
     'rhel-4.6' => undef,
-    'windows' => {
-        NAME         => 'L9088A',
-        SERIAL       => '2000417915',
-        DATE         => '19/09/2002',
-        MANUFACTURER => 'TOSHIBA',
-        CHEMISTRY    => 'Lithium Ion',
-        VOLTAGE      => 10800,
-        CAPACITY     => 0
-    },
+    'windows' => [
+        {
+            NAME         => 'L9088A',
+            SERIAL       => '2000417915',
+            DATE         => '19/09/2002',
+            MANUFACTURER => 'Toshiba',
+            CHEMISTRY    => 'Lithium Ion',
+            VOLTAGE      => 10800,
+            CAPACITY     => 0
+        }
+    ],
     'windows-hyperV' => undef
+);
+
+my %testUpowerMerged = (
+    'infos_1.txt' => {
+        files => {
+            dmidecode => 'dmi_decode.txt',
+            upowerInfos => {
+                '/org/freedesktop/UPower/devices/battery_BAT1' => 'infos_1.txt',
+            },
+            upowerNames => 'enumerate_1.txt'
+        },
+        mergedData => [
+            {
+                NAME         => 'G71C000G7210',
+                CAPACITY     => '39,264 Wh',
+                VOLTAGE      => '14,8 V',
+                CHEMISTRY    => 'lithium-ion',
+                SERIAL       => 0,
+                MANUFACTURER => 'Toshiba',
+                DATE         => undef
+            }
+        ]
+    }
 );
 
 plan tests =>
     (scalar keys %tests)               +
     (scalar grep { $_ } values %tests) +
+    (scalar keys %testUpowerMerged) * 5 +
     1;
 
+my $batterySectionName = 'BATTERIES';
 my $inventory = FusionInventory::Test::Inventory->new();
 
 foreach my $test (keys %tests) {
     my $file = "resources/generic/dmidecode/$test";
-    my $battery = FusionInventory::Agent::Task::Inventory::Generic::Dmidecode::Battery::_getBattery(file => $file);
-    cmp_deeply($battery, $tests{$test}, "$test: parsing");
-    next unless $battery;
+    my $batteries = FusionInventory::Agent::Task::Inventory::Generic::Dmidecode::Battery::_getBatteries(file => $file);
+    cmp_deeply($batteries, $tests{$test}, "$test: parsing");
+    next unless $batteries;
     lives_ok {
-        $inventory->addEntry(section => 'BATTERIES', entry => $battery);
-    } "$test: registering";
+            $inventory->addEntry(section => $batterySectionName, entry => $batteries->[0]);
+        } "$test: registering";
+}
+
+my $filesPath = 'resources/generic/batteries/upower/';
+foreach my  $test (keys %testUpowerMerged) {
+    $inventory = FusionInventory::Test::Inventory->new();
+
+    my @batteriesName = FusionInventory::Agent::Task::Inventory::Generic::Batteries::Upower::_getBatteriesNameFromUpower(
+        file => $filesPath . $testUpowerMerged{$test}->{files}->{upowerNames}
+    );
+    ok (@batteriesName && (scalar @batteriesName == 1));
+
+    my @batteriesData = ();
+    foreach my $battName (@batteriesName) {
+        my $battData = FusionInventory::Agent::Task::Inventory::Generic::Batteries::Upower::_getBatteryDataFromUpower(
+            file => $filesPath . $testUpowerMerged{$test}->{files}->{upowerInfos}->{$battName}
+        );
+        push @batteriesData, $battData
+    }
+    ok (@batteriesData && (scalar @batteriesData == 1));
+
+    foreach my $batt (@batteriesData) {
+        $inventory->setBatteryUsingIndex($batt);
+    }
+    my $section = $inventory->getSection($batterySectionName);
+    ok (defined $section && scalar @$section == 1);
+
+    my @batteriesFromDmiDecode = FusionInventory::Agent::Task::Inventory::Generic::Dmidecode::Battery::_getBatteries(
+        file => $filesPath . $testUpowerMerged{$test}->{files}->{dmidecode}
+    );
+    FusionInventory::Agent::Task::Inventory::Generic::Dmidecode::Battery::_mergeBatteries($inventory, @batteriesFromDmiDecode);
+
+    $section = $inventory->getSection($batterySectionName);
+    ok (
+        defined $section && scalar @$section == 1,
+            'defined $section : ' . ((not defined $section) ? 'not' : '' . ' defined ; ') . ((defined $section) ? scalar @$section : '')
+    );
+    my @section = sort { $a->{NAME} cmp $b->{NAME} && $a->{SERIAL} cmp $b->{SERIAL} } @$section;
+    my @expected = sort { $a->{NAME} cmp $b->{NAME} && $a->{SERIAL} cmp $b->{SERIAL} } @{$testUpowerMerged{$test}->{mergedData}};
+    cmp_deeply (
+        \@section,
+        \@expected,
+        "$test _mergeBatteries()"
+    );
 }


### PR DESCRIPTION
- correction of algorithm to extract all batteries and not only the first one found
- priority to data provided by 'upower' (linux)
- dmidecode data fills empty fields only
- use of tools function getCanonicalManufacturer() to normalize batteries' manufacturer name
- in tools function getCanonicalManufacturer() : 'lg' is a too short pattern, so changing it to 'lg(?:\s|$)' and changing corresponding unit tests