### PR TITLE
Update memory component capacity on virtual systems

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory.pm
@@ -253,11 +253,15 @@ sub _runModule {
         die "module $other_module, needed before $module, not found"
             if !$self->{modules}->{$other_module};
 
-        next if (!$self->{modules}->{$other_module}->{enabled} &&
-            $self->{modules}->{$module}->{runAfterIfEnabled}->{$other_module});
-
-        die "module $other_module, needed before $module, not enabled"
-            if !$self->{modules}->{$other_module}->{enabled};
+        if (!$self->{modules}->{$other_module}->{enabled}) {
+            if ($self->{modules}->{$module}->{runAfterIfEnabled}->{$other_module}) {
+                # soft dependency: run current module without required one
+                next;
+            } else {
+                # hard dependency: abort current module execution
+                die "module $other_module, needed before $module, not enabled";
+            }
+        }
 
         die "circular dependency between $module and $other_module"
             if $self->{modules}->{$other_module}->{used};


### PR DESCRIPTION
On virtual systems, memory capacity is often exposed as one component. dmidecode only reports initial capacity in that case. This PR updates the component capacity to the total memory size set in HARDWARE section in such case. So any virtually allocated memory change will be also reported by the agent at the memory component level.

I had to introduce escape conditions support in inventory module dependencies as total memory size is detected in platform dependent modules.