### PR TITLE
Better cleanup canonical strings after first invalid character

### DIFF
--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -930,8 +930,8 @@ sub _getCanonicalString {
     $value = hex2char($value);
     return unless $value;
 
-    # truncate after first null-character
-    $value =~ s/\000.*$//;
+    # truncate after first invalid character
+    $value =~ s/[[:^print:]].*$//;
 
     # unquote string
     $value =~ s/^\\?["']//;


### PR DESCRIPTION
This was tested with enterasys snmp walk to fixes #336 and generates an inventory which could be included server-side without error even if it was not exact regarding CDP cache info integration. More work will have to be done later on that to identify problematic case.