### PR TITLE
Fix win32 softwares disappear if at least 2 'inventory' are set in tasks

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/Win32/Softwares.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Win32/Softwares.pm
@@ -126,6 +126,8 @@ sub doInventory {
         _addSoftware(inventory => $inventory, entry => $hotfix);
     }
 
+    # Reset seen hash so we can see softwares in later same run inventory
+    $seen = {};
 }
 
 sub _loadUserSoftware {


### PR DESCRIPTION
Fix #344 