### PR TITLE
2.3.x+fix hardware manufacturer to real vendor

### DIFF
--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -99,6 +99,11 @@ my @sysdescr_rules = (
     },
 );
 
+# rules on model name to reset manufacturer to real vendor
+my %sysmodel_first_word = (
+    'dell'           => { manufacturer => 'Dell', },
+);
+
 # common base variables
 my %base_variables = (
     CPU          => {
@@ -336,9 +341,13 @@ sub getDeviceInfo {
         $device->{MANUFACTURER} = $manufacturer if $manufacturer;
     }
 
-    # fallback vendor, using manufacturer
-    if (!exists $device->{VENDOR} && exists $device->{MANUFACTURER}) {
-        $device->{VENDOR} = $device->{MANUFACTURER};
+    # reset manufacturer by rule as real vendor based on first model word
+    if (exists $device->{MODEL}) {
+        my ($first_word) = $device->{MODEL} =~ /(\S+)/;
+        my $result = $sysmodel_first_word{lc($first_word)};
+        if ($result && $result->{manufacturer}) {
+            $device->{MANUFACTURER} = $result->{manufacturer};
+        }
     }
 
     # remaining informations

--- a/resources/walks/sample4.result
+++ b/resources/walks/sample4.result
@@ -32,7 +32,6 @@
         <SERIAL>SG707SU03Y</SERIAL>
         <TYPE>NETWORKING</TYPE>
         <UPTIME>(293555959) 33 days, 23:25:59.59</UPTIME>
-        <VENDOR>Hewlett-Packard</VENDOR>
       </INFO>
       <PORTS>
         <PORT>

--- a/t/agent/tools/hardware.t
+++ b/t/agent/tools/hardware.t
@@ -262,7 +262,6 @@ cmp_deeply(
         DESCRIPTION  => 'foo',
         TYPE         => 'NETWORKING',
         MANUFACTURER => 'Nortel',
-        VENDOR       => 'Nortel'
     },
     'getDeviceInfo() with sysobjectid'
 );
@@ -278,7 +277,6 @@ cmp_deeply(
     {
         TYPE         => 'NETWORKING',
         MANUFACTURER => 'Qlogic',
-        VENDOR       => 'Qlogic',
         MODEL        => 'SANbox 5602 FC Switch',
         EXTMOD       => 'Qlogic'
     },


### PR DESCRIPTION
Remove VENDOR from netdiscovery/netinventory
Reset MANUFACTURER to well-known real vendor based on detected vendor as model first word
Actually only dell is recognized.