### PR TITLE
2.3.x+snmp hardware fixes

### DIFF
--- a/lib/FusionInventory/Agent/Tools.pm
+++ b/lib/FusionInventory/Agent/Tools.pm
@@ -31,6 +31,7 @@ our @EXPORT = qw(
     getCanonicalInterfaceSpeed
     getCanonicalSize
     getSanitizedString
+    getUtf8String
     trimWhitespace
     getFirstLine
     getFirstMatch
@@ -230,13 +231,10 @@ sub compareVersion {
         );
 }
 
-sub getSanitizedString {
+sub getUtf8String {
     my ($string) = @_;
 
     return unless defined $string;
-
-    # clean control caracters
-    $string =~ s/[[:cntrl:]]//g;
 
     # encode to utf-8 if needed
     if (!Encode::is_utf8($string) && $string !~ m/\A(
@@ -253,6 +251,17 @@ sub getSanitizedString {
     };
 
     return $string;
+}
+
+sub getSanitizedString {
+    my ($string) = @_;
+
+    return unless defined $string;
+
+    # clean control caracters
+    $string =~ s/[[:cntrl:]]//g;
+
+    return getUtf8String($string);
 }
 
 sub trimWhitespace {
@@ -598,6 +607,10 @@ Returns a normalized size value (in Mb) for given one.
 
 Returns the input stripped from any control character, properly encoded in
 UTF-8.
+
+=head2 getUtf8String($string)
+
+Returns the input properly encoded in UTF-8.
 
 =head2 trimWhitespace($string)
 

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -939,14 +939,20 @@ sub _getCanonicalString {
     $value = hex2char($value);
     return unless $value;
 
-    # truncate after first invalid character but keep newline as valid
-    $value =~ s/[^[:print:]\n].*$//;
-
     # unquote string
     $value =~ s/^\\?["']//;
     $value =~ s/\\?["']$//;
 
     return unless $value;
+
+    # Be sure to work on utf-8 string
+    $value = getUtf8String($value);
+
+    # reduce linefeeds which can be found in descriptions or comments
+    $value =~ s/\p{Control}+\n/\n/g;
+
+    # truncate after first invalid character but keep newline as valid
+    $value =~ s/[^\p{Print}\n].*$//;
 
     return $value;
 }

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -1554,7 +1554,7 @@ sub _getVlans {
     my $vlanIdName = $snmp->walk('.1.0.8802.1.1.2.1.5.32962.1.2.3.1.2');
     my $portLink = $snmp->walk('.1.0.8802.1.1.2.1.3.7.1.3');
     if($vlanIdName && $portLink){
-        while (my ($suffix, $vlanName) = each %{$vlanIdName}) {
+        foreach my $suffix (sort keys %{$vlanIdName}) {
             my ($port, $vlan) = split(/\./, $suffix);
             if ($portLink->{$port}) {
                 # case generic where $portLink = port number
@@ -1565,7 +1565,7 @@ sub _getVlans {
                 }
                 push @{$results->{$portnumber}}, {
                     NUMBER => $vlan,
-                    NAME   => $vlanName
+                    NAME   => $vlanIdName->{$suffix}
                 };
             }
         }
@@ -1573,10 +1573,10 @@ sub _getVlans {
         # A last method
         my $vlanId = $snmp->walk('.1.0.8802.1.1.2.1.5.32962.1.2.1.1.1');
         if($vlanId){
-            while (my ($port, $vlan) = each %{$vlanId}) {
+            foreach my $port (sort keys %{$vlanId}) {
                 push @{$results->{$port}}, {
-                    NUMBER => $vlan,
-                    NAME   => "VLAN " . $vlan
+                    NUMBER => $vlanId->{$port},
+                    NAME   => "VLAN " . $vlanId->{$port}
                 };
             }
         }

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -291,7 +291,7 @@ sub getDeviceInfo {
     # if one of them is missing
     my $sysdescr = $snmp->get('.1.3.6.1.2.1.1.1.0');
     if ($sysdescr) {
-        $device->{DESCRIPTION} = $sysdescr;
+        $device->{DESCRIPTION} = _getCanonicalString($sysdescr);
 
         if (!exists $device->{MANUFACTURER} || !exists $device->{TYPE}) {
             # first word

--- a/lib/FusionInventory/Agent/Tools/Network.pm
+++ b/lib/FusionInventory/Agent/Tools/Network.pm
@@ -139,7 +139,7 @@ sub alt2canonical {
     my ($address) = @_;
     return unless $address;
 
-    my @bytes = $address =~ /^(?:0x)?(..)[ :-]?(..)[ :-]?(..)[ :-]?(..)[ :-]?(..)[ :-]?(..)$/;
+    my @bytes = $address =~ /^(?:0x)?([[:xdigit:]]{2})[ :-]?([[:xdigit:]]{2})[ :-]?([[:xdigit:]]{2})[ :-]?([[:xdigit:]]{2})[ :-]?([[:xdigit:]]{2})[ :-]?([[:xdigit:]]{2})$/;
     return join(':', @bytes);
 }
 


### PR DESCRIPTION
This PR makes netinventory more reliable when listing VLANs and so this helps compare results during snmp walks tests.
Canonical string API is also safer and produce utf-8 characters.
Device description is now a canonical string to remove unwanted chars.
Also updated alt2canonical API mac address regexp to be a lot more accurate.