### PR TITLE
Fix issue #329 : fusioninventory-injector always returns exit code 0

### DIFF
--- a/bin/fusioninventory-injector
+++ b/bin/fusioninventory-injector
@@ -15,6 +15,8 @@ my $options = {
     useragent => 'FusionInventory-Injector'
 };
 
+my @failedFiles;
+
 GetOptions(
     $options,
     'help|h',
@@ -44,9 +46,12 @@ eval {
         pod2usage();
     }
 };
-if ($@) {
-    print $@;
-    exit(1);
+if ($EVAL_ERROR) {
+    die "$EVAL_ERROR\n";
+} elsif (scalar @failedFiles > 0) {
+    my $message = 'These elements were not sent:' . "\n";
+    $message .= join "\n", @failedFiles;
+    die($message . "\n");
 }
 
 exit(0);
@@ -70,6 +75,8 @@ sub loadfile {
     if ($success && $options->{remove}) {
         unlink $file or warn "Can't remove $file: $ERRNO\n"
     }
+
+    push @failedFiles, $file unless $success;
 }
 
 sub loaddirectory {
@@ -95,7 +102,7 @@ sub loadstdin {
     my $content;
     undef $RS;
     $content = <STDIN>;
-    sendContent($content);
+    push @failedFiles, 'STDIN DATA' unless sendContent($content);
 }
 
 sub sendContent {
@@ -130,9 +137,6 @@ sub sendContent {
     if ($options->{verbose}) {
         print $res->is_success() ?
             "OK\n" : "ERROR: " . $res->status_line() . "\n";
-    }
-    unless ($res->is_success()) {
-        die "Content has not been sent. HTTP status is : " . $res->status_line . "\n";
     }
 
     return $res->is_success();

--- a/bin/fusioninventory-injector
+++ b/bin/fusioninventory-injector
@@ -33,14 +33,20 @@ GetOptions(
 $OUTPUT_AUTOFLUSH = 1;
 pod2usage(-verbose => 0, -exitstatus => 0) if $options->{help};
 
-if ($options->{stdin}) {
-    loadstdin();
-} elsif ($options->{file}) {
-    loadfile($options->{file});
-} elsif ($options->{directory}) {
-    loaddirectory($options->{directory});
-} else {
-    pod2usage();
+eval {
+    if ($options->{stdin}) {
+        loadstdin();
+    } elsif ($options->{file}) {
+        loadfile($options->{file});
+    } elsif ($options->{directory}) {
+        loaddirectory($options->{directory});
+    } else {
+        pod2usage();
+    }
+};
+if ($@) {
+    print $@;
+    exit(1);
 }
 
 exit(0);
@@ -124,6 +130,9 @@ sub sendContent {
     if ($options->{verbose}) {
         print $res->is_success() ?
             "OK\n" : "ERROR: " . $res->status_line() . "\n";
+    }
+    unless ($res->is_success()) {
+        die "Content has not been sent. HTTP message is : " . $res->code . ' ' . $res->message;
     }
 
     return $res->is_success();

--- a/bin/fusioninventory-injector
+++ b/bin/fusioninventory-injector
@@ -35,20 +35,16 @@ GetOptions(
 $OUTPUT_AUTOFLUSH = 1;
 pod2usage(-verbose => 0, -exitstatus => 0) if $options->{help};
 
-eval {
-    if ($options->{stdin}) {
-        loadstdin();
-    } elsif ($options->{file}) {
-        loadfile($options->{file});
-    } elsif ($options->{directory}) {
-        loaddirectory($options->{directory});
-    } else {
-        pod2usage();
-    }
-};
-if ($EVAL_ERROR) {
-    die "$EVAL_ERROR\n";
-} elsif (scalar @failedFiles > 0) {
+if ($options->{stdin}) {
+    loadstdin();
+} elsif ($options->{file}) {
+    loadfile($options->{file});
+} elsif ($options->{directory}) {
+    loaddirectory($options->{directory});
+} else {
+    pod2usage();
+}
+if (scalar @failedFiles > 0) {
     my $message = 'These elements were not sent:' . "\n";
     $message .= join "\n", @failedFiles;
     die($message . "\n");

--- a/bin/fusioninventory-injector
+++ b/bin/fusioninventory-injector
@@ -54,8 +54,8 @@ exit(0);
 sub loadfile {
     my ($file) = @_;
 
-    die "file $file does not exist" unless -f $file;
-    die "file $file is not readable" unless -r $file;
+    die "file $file does not exist\n" unless -f $file;
+    die "file $file is not readable\n" unless -r $file;
 
     print "Loading $file..." if $options->{verbose};
 
@@ -75,8 +75,8 @@ sub loadfile {
 sub loaddirectory {
     my ($directory) = @_;
 
-    die "directory $directory does not exist" unless -d $directory;
-    die "directory $directory is not readable" unless -r $directory;
+    die "directory $directory does not exist\n" unless -d $directory;
+    die "directory $directory is not readable\n" unless -r $directory;
 
     opendir (my $handle, $directory)
         or die "can't open directory $directory: $ERRNO\n";
@@ -132,7 +132,7 @@ sub sendContent {
             "OK\n" : "ERROR: " . $res->status_line() . "\n";
     }
     unless ($res->is_success()) {
-        die "Content has not been sent. HTTP status is : " . $res->status_line;
+        die "Content has not been sent. HTTP status is : " . $res->status_line . "\n";
     }
 
     return $res->is_success();

--- a/bin/fusioninventory-injector
+++ b/bin/fusioninventory-injector
@@ -132,7 +132,7 @@ sub sendContent {
             "OK\n" : "ERROR: " . $res->status_line() . "\n";
     }
     unless ($res->is_success()) {
-        die "Content has not been sent. HTTP message is : " . $res->code . ' ' . $res->message;
+        die "Content has not been sent. HTTP status is : " . $res->status_line;
     }
 
     return $res->is_success();


### PR DESCRIPTION
issue #329 
Catch exceptions. 
If caught exception, print exception message and do exit with non-zero integer.
