### PR TITLE
2.4.x+netinventory mibsupport detection

### DIFF
--- a/lib/FusionInventory/Agent/SNMP/Device.pm
+++ b/lib/FusionInventory/Agent/SNMP/Device.pm
@@ -117,6 +117,56 @@ sub addSimcard {
     push @{$self->{SIMCARDS}}, $simcard;
 }
 
+sub setSerial {
+    my ($self) = @_;
+
+    # Entity-MIB::entPhysicalSerialNum
+    my $entPhysicalSerialNum = $self->{snmp}->get_first('.1.3.6.1.2.1.47.1.1.1.1.11');
+    return $self->{SERIAL} = _getCanonicalSerialNumber($entPhysicalSerialNum)
+        if $entPhysicalSerialNum;
+
+    # Printer-MIB::prtGeneralSerialNumber
+    my $prtGeneralSerialNumber = $self->{snmp}->get_first('.1.3.6.1.2.1.43.5.1.1.17');
+    return $self->{SERIAL} = _getCanonicalSerialNumber($prtGeneralSerialNumber)
+        if $prtGeneralSerialNumber;
+
+    # vendor specific OIDs
+    my @oids = (
+        '.1.3.6.1.4.1.2636.3.1.3.0',             # Juniper-MIB
+        '.1.3.6.1.4.1.248.14.1.1.9.1.10.1',      # Hirschman MIB
+        '.1.3.6.1.4.1.253.8.53.3.2.1.3.1',       # Xerox-MIB
+        '.1.3.6.1.4.1.367.3.2.1.2.1.4.0',        # Ricoh-MIB
+        '.1.3.6.1.4.1.641.2.1.2.1.6.1',          # Lexmark-MIB
+        '.1.3.6.1.4.1.1602.1.2.1.4.0',           # Canon-MIB
+        '.1.3.6.1.4.1.2435.2.3.9.4.2.1.5.5.1.0', # Brother-MIB
+        '.1.3.6.1.4.1.318.1.1.4.1.5.0',          # MasterSwitch-MIB
+        '.1.3.6.1.4.1.6027.3.8.1.1.5.0',         # F10-C-SERIES-CHASSIS-MIB
+        '.1.3.6.1.4.1.6027.3.10.1.2.2.1.12.1',   # FORCE10-SMI
+        '.1.3.6.1.4.1.16378.10000.3.15.0',       # DIGI-Sarian-Monitor
+    );
+    foreach my $oid (@oids) {
+        my $value = $self->{snmp}->get($oid);
+        next unless $value;
+        $self->{SERIAL} = _getCanonicalSerialNumber($value);
+        last;
+    }
+}
+
+sub _getCanonicalSerialNumber {
+    my ($value) = @_;
+
+    $value = hex2char($value);
+    return unless $value;
+
+    $value =~ s/[[:^print:]]//g;
+    $value =~ s/^\s+//;
+    $value =~ s/\s+$//;
+    $value =~ s/\.{2,}//g;
+    return unless $value;
+
+    return $value;
+}
+
 1;
 
 __END__

--- a/lib/FusionInventory/Agent/SNMP/Device.pm
+++ b/lib/FusionInventory/Agent/SNMP/Device.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use FusionInventory::Agent::Tools;
 use FusionInventory::Agent::Tools::SNMP;
+use FusionInventory::Agent::Tools::Network;
 use FusionInventory::Agent::SNMP::MibSupport;
 
 # Supported infos are specified here:
@@ -36,14 +37,30 @@ sub new {
     return $self;
 }
 
+sub get {
+    my ($self, $oid) = @_;
+
+    return unless $self->{snmp} && $oid;
+
+    return $self->{snmp}->get($oid);
+}
+
+sub walk {
+    my ($self, $oid) = @_;
+
+    return unless $self->{snmp} && $oid;
+
+    return $self->{snmp}->walk($oid);
+}
+
 sub loadMibSupport {
-    my ($self) = @_;
+    my ($self, $sysobjectid) = @_;
 
     # list supported mibs regarding sysORID list as this list permits to
     # identify device supported MIBs
     $self->{MIBSUPPORT} = FusionInventory::Agent::SNMP::MibSupport->new(
-        sysorid_list => $self->{snmp}->walk('.1.3.6.1.2.1.1.9.1.2'),
-        logger       => $self->{logger}
+        sysobjectid  => $sysobjectid,
+        device       => $self
     );
 }
 
@@ -52,16 +69,7 @@ sub runMibSupport {
 
     return unless $self->{MIBSUPPORT};
 
-    foreach my $mibsupport ($self->{MIBSUPPORT}->get()) {
-        runFunction(
-            module   => $mibsupport->{module},
-            function => "run",
-            logger   => $self->{logger},
-            params   => {
-                device => $self
-            }
-        );
-    }
+    $self->{MIBSUPPORT}->run();
 }
 
 sub getSerialByMibSupport {
@@ -69,20 +77,7 @@ sub getSerialByMibSupport {
 
     return unless $self->{MIBSUPPORT};
 
-    my $serial;
-    foreach my $mibsupport ($self->{MIBSUPPORT}->get()) {
-        $serial = runFunction(
-            module   => $mibsupport->{module},
-            function => "getSerial",
-            logger   => $self->{logger},
-            params   => {
-                device => $self
-            }
-        );
-        last if defined $serial;
-    }
-
-    return $serial;
+    return $self->{MIBSUPPORT}->getMethod('getSerial');
 }
 
 sub getFirmwareByMibSupport {
@@ -90,20 +85,31 @@ sub getFirmwareByMibSupport {
 
     return unless $self->{MIBSUPPORT};
 
-    my $firmware;
-    foreach my $mibsupport ($self->{MIBSUPPORT}->get()) {
-        $firmware = runFunction(
-            module   => $mibsupport->{module},
-            function => "getFirmware",
-            logger   => $self->{logger},
-            params   => {
-                device => $self
-            }
-        );
-        last if defined $firmware;
-    }
+    return $self->{MIBSUPPORT}->getMethod('getFirmware');
+}
 
-    return $firmware;
+sub getFirmwareDateByMibSupport {
+    my ($self) = @_;
+
+    return unless $self->{MIBSUPPORT};
+
+    return $self->{MIBSUPPORT}->getMethod('getFirmwareDate');
+}
+
+sub getMacAddressByMibSupport {
+    my ($self) = @_;
+
+    return unless $self->{MIBSUPPORT};
+
+    return $self->{MIBSUPPORT}->getMethod('getMacAddress');
+}
+
+sub getIpByMibSupport {
+    my ($self) = @_;
+
+    return unless $self->{MIBSUPPORT};
+
+    return $self->{MIBSUPPORT}->getMethod('getIp');
 }
 
 sub getDiscoveryInfo {
@@ -139,7 +145,7 @@ sub getInventory {
 sub addModem {
     my ($self, $modem) = @_;
 
-    return unless $modem;
+    return unless _cleanHash($modem);
 
     push @{$self->{MODEMS}}, $modem;
 }
@@ -147,7 +153,7 @@ sub addModem {
 sub addFirmware {
     my ($self, $firmware) = @_;
 
-    return unless $firmware;
+    return unless _cleanHash($firmware);
 
     push @{$self->{FIRMWARES}}, $firmware;
 }
@@ -155,48 +161,71 @@ sub addFirmware {
 sub addSimcard {
     my ($self, $simcard) = @_;
 
-    return unless $simcard;
+    return unless _cleanHash($simcard);
 
     push @{$self->{SIMCARDS}}, $simcard;
+}
+
+sub addPort {
+    my ($self, %ports) = @_;
+
+    foreach my $port (keys(%ports)) {
+        next unless _cleanHash($ports{$port});
+
+        $self->{PORTS}->{PORT}->{$port} = $ports{$port};
+    }
+}
+
+sub _cleanHash {
+    my ($hashref) = @_;
+
+    return unless ref($hashref) eq 'HASH';
+
+    my $keys = 0 ;
+    foreach my $key (keys(%{$hashref})) {
+        $keys++;
+        next if defined($hashref->{$key});
+        delete $hashref->{$key};
+        $keys--,
+    }
+
+    return $keys;
 }
 
 sub setSerial {
     my ($self) = @_;
 
-    # Entity-MIB::entPhysicalSerialNum
-    my $entPhysicalSerialNum = $self->{snmp}->get_first('.1.3.6.1.2.1.47.1.1.1.1.11');
-    return $self->{SERIAL} = getCanonicalSerialNumber($entPhysicalSerialNum)
-        if $entPhysicalSerialNum;
+    my $serial =
+        # Entity-MIB::entPhysicalSerialNum
+        $self->{snmp}->get_first('.1.3.6.1.2.1.47.1.1.1.1.11') ||
+        # Printer-MIB::prtGeneralSerialNumber
+        $self->{snmp}->get_first('.1.3.6.1.2.1.43.5.1.1.17') ||
+        # Try MIB Support mechanism
+        $self->getSerialByMibSupport();
 
-    # Printer-MIB::prtGeneralSerialNumber
-    my $prtGeneralSerialNumber = $self->{snmp}->get_first('.1.3.6.1.2.1.43.5.1.1.17');
-    return $self->{SERIAL} = getCanonicalSerialNumber($prtGeneralSerialNumber)
-        if $prtGeneralSerialNumber;
-
-    # Try MIB Support mechanism
-    my $otherSerial = $self->getSerialByMibSupport();
-    return $self->{SERIAL} = getCanonicalSerialNumber($otherSerial)
-        if $otherSerial;
-
-    # vendor specific OIDs
-    my @oids = (
-        '.1.3.6.1.4.1.2636.3.1.3.0',             # Juniper-MIB
-        '.1.3.6.1.4.1.248.14.1.1.9.1.10.1',      # Hirschman MIB
-        '.1.3.6.1.4.1.253.8.53.3.2.1.3.1',       # Xerox-MIB
-        '.1.3.6.1.4.1.367.3.2.1.2.1.4.0',        # Ricoh-MIB
-        '.1.3.6.1.4.1.641.2.1.2.1.6.1',          # Lexmark-MIB
-        '.1.3.6.1.4.1.1602.1.2.1.4.0',           # Canon-MIB
-        '.1.3.6.1.4.1.2435.2.3.9.4.2.1.5.5.1.0', # Brother-MIB
-        '.1.3.6.1.4.1.318.1.1.4.1.5.0',          # MasterSwitch-MIB
-        '.1.3.6.1.4.1.6027.3.8.1.1.5.0',         # F10-C-SERIES-CHASSIS-MIB
-        '.1.3.6.1.4.1.6027.3.10.1.2.2.1.12.1',   # FORCE10-SMI
-    );
-    foreach my $oid (@oids) {
-        my $value = $self->{snmp}->get($oid);
-        next unless $value;
-        $self->{SERIAL} = getCanonicalSerialNumber($value);
-        last;
+    if ( not defined $serial ) {
+        # vendor specific OIDs
+        my @oids = (
+            '.1.3.6.1.4.1.2636.3.1.3.0',             # Juniper-MIB
+            '.1.3.6.1.4.1.248.14.1.1.9.1.10.1',      # Hirschman MIB
+            '.1.3.6.1.4.1.253.8.53.3.2.1.3.1',       # Xerox-MIB
+            '.1.3.6.1.4.1.367.3.2.1.2.1.4.0',        # Ricoh-MIB
+            '.1.3.6.1.4.1.641.2.1.2.1.6.1',          # Lexmark-MIB
+            '.1.3.6.1.4.1.1602.1.2.1.4.0',           # Canon-MIB
+            '.1.3.6.1.4.1.2435.2.3.9.4.2.1.5.5.1.0', # Brother-MIB
+            '.1.3.6.1.4.1.318.1.1.4.1.5.0',          # MasterSwitch-MIB
+            '.1.3.6.1.4.1.6027.3.8.1.1.5.0',         # F10-C-SERIES-CHASSIS-MIB
+            '.1.3.6.1.4.1.6027.3.10.1.2.2.1.12.1',   # FORCE10-SMI
+        );
+        foreach my $oid (@oids) {
+            $serial = $self->get($oid);
+            last if $serial;
+        }
     }
+
+    return unless $serial;
+
+    $self->{SERIAL} = getCanonicalSerialNumber($serial);
 }
 
 sub setFirmware {
@@ -218,7 +247,7 @@ sub setFirmware {
             '.1.3.6.1.4.1.2636.3.40.1.4.1.1.1.5.0',  # Juniper-MIB
         );
         foreach my $oid (@oids) {
-            $firmware = $self->{snmp}->get($oid);
+            $firmware = $self->get($oid);
             last if defined $firmware;
         }
     }
@@ -233,9 +262,95 @@ sub setFirmware {
         NAME            => $self->{MODEL} || 'device',
         DESCRIPTION     => 'device firmware',
         TYPE            => 'device',
+        DATE            => $self->getFirmwareDateByMibSupport(),
         VERSION         => $self->{FIRMWARE},
         MANUFACTURER    => $self->{MANUFACTURER}
     });
+}
+
+sub setMacAddress {
+    my ($self) = @_;
+
+    my $address_oid = ".1.3.6.1.2.1.17.1.1.0";
+    my $address = getCanonicalMacAddress(
+        # use BRIDGE-MIB::dot1dBaseBridgeAddress if available
+        $self->get($address_oid) ||
+        # Try MIB Support mechanism
+        $self->getMacAddressByMibSupport()
+    );
+
+    return $self->{MAC} = $address
+        if $address && $address =~ /^$mac_address_pattern$/;
+
+    # fallback on ports addresses (IF-MIB::ifPhysAddress) if unique
+    my $addresses_oid = ".1.3.6.1.2.1.2.2.1.6";
+    my $addresses = $self->walk($addresses_oid);
+
+    # interfaces list with defined ip to use as filter to select shorter mac address list
+    my $ips = $self->walk('.1.3.6.1.2.1.4.20.1.2');
+
+    my @all_mac_addresses = ();
+
+    # Try first to obtain shorter mac address list using ip interface list filter
+    @all_mac_addresses = grep { defined } map { $addresses->{$_} } values %{$ips}
+        if (keys(%{$ips}));
+
+    # Finally get all defined mac adresses if ip filtered related list remains empty
+    @all_mac_addresses = grep { defined } values %{$addresses}
+        unless @all_mac_addresses;
+
+    my @valid_mac_addresses =
+        uniq
+        grep { /^$mac_address_pattern$/ }
+        grep { $_ ne '00:00:00:00:00:00' }
+        grep { $_ }
+        map  { getCanonicalMacAddress($_) }
+        @all_mac_addresses;
+
+    if (@valid_mac_addresses) {
+        return $self->{MAC} = $valid_mac_addresses[0]
+            if @valid_mac_addresses == 1;
+
+        # Compute mac addresses as number and sort them
+        my %macs = map { $_ => _numericMac($_) } @valid_mac_addresses;
+        my @sortedMac = sort { $macs{$a} <=> $macs{$b} } @valid_mac_addresses;
+
+        # Then find first couple of consecutive mac and return first one as this
+        # seems to be the first manufacturer defined mac address
+        while (@sortedMac > 1) {
+            my $currentMac = shift @sortedMac;
+            return $self->{MAC} = $currentMac
+                if ($macs{$currentMac} == $macs{$sortedMac[0]} - 1);
+        }
+    }
+}
+
+sub _numericMac {
+    my ($mac) = @_;
+
+    my $number = 0;
+    my $multiplicator = 1;
+
+    my @parts = split(':', $mac);
+    while (@parts) {
+        $number += hex(pop(@parts))*$multiplicator;
+        $multiplicator <<= 8 ;
+    }
+
+    return $number;
+}
+
+
+sub setIp {
+    my ($self) = @_;
+
+    my $results = $self->walk('.1.3.6.1.2.1.4.20.1.1');
+    return $self->{IPS}->{IP} = [
+        sort values %{$results}
+    ] if $results;
+
+    my $ip = $self->getIpByMibSupport();
+    $self->{IPS}->{IP} = [ $ip ] if $ip;
 }
 
 1;

--- a/lib/FusionInventory/Agent/SNMP/Device.pm
+++ b/lib/FusionInventory/Agent/SNMP/Device.pm
@@ -178,6 +178,31 @@ sub setSerial {
     }
 }
 
+sub setFirmware {
+    my ($self) = @_;
+
+    my $entPhysicalSoftwareRev = $self->{snmp}->get_first('.1.3.6.1.2.1.47.1.1.1.1.10');
+    return $self->{FIRMWARE} = $entPhysicalSoftwareRev
+        if $entPhysicalSoftwareRev;
+
+    my $entPhysicalFirmwareRev = $self->{snmp}->get_first('.1.3.6.1.2.1.47.1.1.1.1.9');
+    return $self->{FIRMWARE} = $entPhysicalFirmwareRev
+        if $entPhysicalFirmwareRev;
+
+    # vendor specific OIDs
+    my @oids = (
+        '.1.3.6.1.4.1.9.9.25.1.1.1.2.5',         # Cisco / IOS
+        '.1.3.6.1.4.1.248.14.1.1.2.0',           # Hirschman MIB
+        '.1.3.6.1.4.1.2636.3.40.1.4.1.1.1.5.0',  # Juniper-MIB
+    );
+    foreach my $oid (@oids) {
+        my $value = $self->{snmp}->get($oid);
+        next unless $value;
+        $self->{FIRMWARE} = getCanonicalString($value);
+        last;
+    }
+}
+
 1;
 
 __END__

--- a/lib/FusionInventory/Agent/SNMP/Device.pm
+++ b/lib/FusionInventory/Agent/SNMP/Device.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use FusionInventory::Agent::Tools;
+use FusionInventory::Agent::Tools::SNMP;
 use FusionInventory::Agent::SNMP::MibSupport;
 
 # Supported infos are specified here:
@@ -143,17 +144,17 @@ sub setSerial {
 
     # Entity-MIB::entPhysicalSerialNum
     my $entPhysicalSerialNum = $self->{snmp}->get_first('.1.3.6.1.2.1.47.1.1.1.1.11');
-    return $self->{SERIAL} = _getCanonicalSerialNumber($entPhysicalSerialNum)
+    return $self->{SERIAL} = getCanonicalSerialNumber($entPhysicalSerialNum)
         if $entPhysicalSerialNum;
 
     # Printer-MIB::prtGeneralSerialNumber
     my $prtGeneralSerialNumber = $self->{snmp}->get_first('.1.3.6.1.2.1.43.5.1.1.17');
-    return $self->{SERIAL} = _getCanonicalSerialNumber($prtGeneralSerialNumber)
+    return $self->{SERIAL} = getCanonicalSerialNumber($prtGeneralSerialNumber)
         if $prtGeneralSerialNumber;
 
     # Try MIB Support mechanism
     my $otherSerial = $self->getSerialByMibSupport();
-    return $self->{SERIAL} = _getCanonicalSerialNumber($otherSerial)
+    return $self->{SERIAL} = getCanonicalSerialNumber($otherSerial)
         if $otherSerial;
 
     # vendor specific OIDs
@@ -172,24 +173,9 @@ sub setSerial {
     foreach my $oid (@oids) {
         my $value = $self->{snmp}->get($oid);
         next unless $value;
-        $self->{SERIAL} = _getCanonicalSerialNumber($value);
+        $self->{SERIAL} = getCanonicalSerialNumber($value);
         last;
     }
-}
-
-sub _getCanonicalSerialNumber {
-    my ($value) = @_;
-
-    $value = hex2char($value);
-    return unless $value;
-
-    $value =~ s/[[:^print:]]//g;
-    $value =~ s/^\s+//;
-    $value =~ s/\s+$//;
-    $value =~ s/\.{2,}//g;
-    return unless $value;
-
-    return $value;
 }
 
 1;

--- a/lib/FusionInventory/Agent/SNMP/Device.pm
+++ b/lib/FusionInventory/Agent/SNMP/Device.pm
@@ -1,0 +1,145 @@
+package FusionInventory::Agent::SNMP::Device;
+ 
+use strict;
+use warnings;
+
+use FusionInventory::Agent::Tools;
+use FusionInventory::Agent::SNMP::MibSupport;
+
+# Supported infos are specified here:
+# http://fusioninventory.org/documentation/dev/spec/protocol/netdiscovery.html
+use constant discovery => [ qw(
+        DESCRIPTION FIRMWARE ID IPS LOCATION MAC MEMORY MODEL SNMPHOSTNAME TYPE
+        SERIAL UPTIME MANUFACTURER CONTACT AUTHSNMP
+    )];
+# http://fusioninventory.org/documentation/dev/spec/protocol/netinventory.html
+use constant inventory => [ qw(
+        INFO PORTS MODEMS FIRMWARES SIMCARDS PAGECOUNTERS CARTRIDGES
+    )];
+
+sub new {
+    my ($class, %params) = @_;
+
+    my $snmp   = $params{snmp};
+    my $logger = $params{logger};
+
+    return unless $snmp;
+
+    my $self = {
+        snmp   => $snmp,
+        logger => $logger
+    };
+
+    bless $self, $class;
+
+    return $self;
+}
+
+sub loadMibSupport {
+    my ($self) = @_;
+
+    # list supported mibs regarding sysORID list as this list permits to
+    # identify device supported MIBs
+    $self->{MIBSUPPORT} = FusionInventory::Agent::SNMP::MibSupport->new(
+        sysorid_list => $self->{snmp}->walk('.1.3.6.1.2.1.1.9.1.2'),
+        logger       => $self->{logger}
+    );
+}
+
+sub runMibSupport {
+    my ($self) = @_;
+
+    return unless $self->{MIBSUPPORT};
+
+    foreach my $mibsupport ($self->{MIBSUPPORT}->get()) {
+        runFunction(
+            module   => $mibsupport->{module},
+            function => "run",
+            logger   => $self->{logger},
+            params   => {
+                device => $self
+            }
+        );
+    }
+}
+
+sub getDiscoveryInfo {
+    my ($self) = @_;
+
+    my $info = {};
+
+    # Filter out to only keep discovery infos
+    my $infos = discovery;
+    foreach my $infokey (@{$infos}) {
+        $info->{$infokey} = $self->{$infokey}
+            if exists($self->{$infokey});
+    }
+
+    return $info;
+}
+
+sub getInventory {
+    my ($self) = @_;
+
+    my $inventory = {};
+
+    # Filter out to only keep inventory infos
+    my $infos = inventory;
+    foreach my $infokey (@{$infos}) {
+        $inventory->{$infokey} = $self->{$infokey}
+            if exists($self->{$infokey});
+    }
+
+    return $inventory;
+}
+
+sub addModem {
+    my ($self, $modem) = @_;
+
+    return unless $modem;
+
+    push @{$self->{MODEMS}}, $modem;
+}
+
+sub addFirmware {
+    my ($self, $firmware) = @_;
+
+    return unless $firmware;
+
+    push @{$self->{FIRMWARES}}, $firmware;
+}
+
+sub addSimcard {
+    my ($self, $simcard) = @_;
+
+    return unless $simcard;
+
+    push @{$self->{SIMCARDS}}, $simcard;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+FusionInventory::Agent::SNMP::Device - FusionInventory agent SNMP device
+
+=head1 DESCRIPTION
+
+Class to help handle general method to apply on snmp device discovery/inventory
+
+=head1 METHODS
+
+=head2 new(%params)
+
+The constructor. The following parameters are allowed, as keys of the %params
+hash:
+
+=over
+
+=item logger
+
+=item snmp (mandatory)  SNMP session object
+
+=back

--- a/lib/FusionInventory/Agent/SNMP/MibSupport.pm
+++ b/lib/FusionInventory/Agent/SNMP/MibSupport.pm
@@ -1,0 +1,98 @@
+package FusionInventory::Agent::SNMP::MibSupport;
+
+use strict;
+use warnings;
+
+use File::Glob;
+
+use FusionInventory::Agent::Tools;
+
+sub new {
+    my ($class, %params) = @_;
+
+    my $logger  = $params{logger};
+    my $sysorid = $params{sysorid_list};
+
+    return unless $sysorid;
+
+    my $self = {
+        _SUPPORT    => [],
+        logger      => $logger
+    };
+
+    # Load any related sub-module dedicated to MIB support
+    my ($sub_modules_path) = $INC{module2file(__PACKAGE__)} =~ /(.*)\.pm/;
+    my %available_mib_support = ();
+    foreach my $file (File::Glob::bsd_glob("$sub_modules_path/*.pm")) {
+        next unless $file =~ m{$sub_modules_path/(\S+)\.pm$};
+
+        my $module = __PACKAGE__ . "::" . $1;
+        my $supported_mibs = runFunction(
+            module   => $module,
+            function => "mibSupport",
+            logger   => $self->{logger},
+            params   => undef,
+            load     => 1
+        );
+
+        if ($supported_mibs && @{$supported_mibs}) {
+            foreach my $mib_support (@{$supported_mibs}) {
+                my $miboid = $mib_support->{oid}
+                    or next;
+                $mib_support->{module} = $module;
+                # Include support for related OID
+                $available_mib_support{$miboid} = $mib_support;
+            }
+        }
+    }
+
+    # Keep in _SUPPORT only needed mib support
+    foreach my $mibindex (sort keys %{$sysorid}) {
+        my $miboid = $sysorid->{$mibindex};
+        my $supported = $available_mib_support{$miboid}
+            or next;
+        my $mibname = $supported->{name}
+            or next;
+        $logger->debug2("$mibname mib support enabled") if $logger;
+        push @{$self->{_SUPPORT}}, $supported;
+    }
+
+    bless $self, $class;
+
+    return $self;
+}
+
+sub get {
+    my ($self) = @_;
+
+    return @{$self->{_SUPPORT}};
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+FusionInventory::Agent::SNMP::MibSupport - FusionInventory agent SNMP mib support
+
+=head1 DESCRIPTION
+
+Class to help handle vendor-specific mibs support modules
+
+=head1 METHODS
+
+=head2 new(%params)
+
+The constructor. The following parameters are allowed, as keys of the %params
+hash:
+
+=over
+
+=item logger
+
+=item sysorid_list (mandatory)
+
+=item device (mandatory)
+
+=back

--- a/lib/FusionInventory/Agent/SNMP/MibSupport/Digi.pm
+++ b/lib/FusionInventory/Agent/SNMP/MibSupport/Digi.pm
@@ -1,0 +1,64 @@
+package FusionInventory::Agent::SNMP::MibSupport::Digi;
+
+use strict;
+use warnings;
+
+use base 'FusionInventory::Agent::SNMP::MibSupport';
+
+# Constants extracted from Digi Sarian-Monitor.mib
+use constant    sarianMonitor   => ".1.3.6.1.4.1.16378.10000" ;
+use constant    sarianGPRS      => sarianMonitor . ".2" ;
+use constant    sarianSystem    => sarianMonitor . ".3" ;
+
+sub mibSupport {
+    return [
+        {
+            name    => "sarianMonitor",
+            oid     => sarianMonitor
+        }
+    ];
+}
+
+sub run {
+    my (%params) = @_;
+
+    my $device = $params{device};
+    my $snmp   = $params{snmp} || $device->{snmp};
+
+    my $sarianSystem = $snmp->walk(sarianSystem);
+
+    # Handle modem Digi private OIDs if found
+    if ($sarianSystem) {
+        my $modem = {
+            NAME            => "Digi modem",
+            DESCRIPTION     => $sarianSystem->{'14.0'},
+            MODEL           => $sarianSystem->{'19.0'},
+            MANUFACTURER    => "Digi",
+        };
+
+        $device->addModem($modem);
+
+        # Add modem firmware
+        my $modemFirmware = {
+            NAME            => "Digi modem",
+            DESCRIPTION     => "Digi $sarianSystem->{'19.0'} modem",
+            TYPE            => "modem",
+            VERSION         => $sarianSystem->{'20.0'},
+            MANUFACTURER    => "Digi"
+        };
+
+        $device->addFirmware($modemFirmware);
+    }
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Inventory module for Digi modems and associated sim cards & firmwares
+
+=head1 DESCRIPTION
+
+The module adds SIMCARDS, MODEMS & FIRMWARES support for Digi devices

--- a/lib/FusionInventory/Agent/SNMP/MibSupport/Digi.pm
+++ b/lib/FusionInventory/Agent/SNMP/MibSupport/Digi.pm
@@ -53,7 +53,7 @@ sub run {
             my $simcard = {
                 IMSI    => $sarianGPRS->{'21.0'}, # gprsIMSI
                 ICCID   => $sarianGPRS->{'20.0'}, # gprsICCID
-                STATE   => $sarianGPRS->{'26.0'}, # gprsSIMStatus
+                #STATE   => $sarianGPRS->{'26.0'}, # gprsSIMStatus
             };
 
             $device->addSimcard($simcard);

--- a/lib/FusionInventory/Agent/SNMP/MibSupport/Digi.pm
+++ b/lib/FusionInventory/Agent/SNMP/MibSupport/Digi.pm
@@ -21,6 +21,15 @@ sub mibSupport {
 
 my @gprsNetworkTechnology = qw(- unknown gprs edge umts hsdpa hsupa hspa lte);
 
+sub getSerial {
+    my (%params) = @_;
+
+    my $device = $params{device};
+    my $snmp   = $params{snmp} || $device->{snmp};
+
+    return $snmp->get('.1.3.6.1.4.1.16378.10000.3.15.0');
+}
+
 sub run {
     my (%params) = @_;
 

--- a/lib/FusionInventory/Agent/SNMP/MibSupport/Digi.pm
+++ b/lib/FusionInventory/Agent/SNMP/MibSupport/Digi.pm
@@ -21,6 +21,15 @@ sub mibSupport {
 
 my @gprsNetworkTechnology = qw(- unknown gprs edge umts hsdpa hsupa hspa lte);
 
+sub getFirmware {
+    my (%params) = @_;
+
+    my $device = $params{device};
+    my $snmp   = $params{snmp} || $device->{snmp};
+
+    return $snmp->get('.1.3.6.1.4.1.16378.10000.3.16.0');
+}
+
 sub getSerial {
     my (%params) = @_;
 

--- a/lib/FusionInventory/Agent/SNMP/MibSupport/Digi.pm
+++ b/lib/FusionInventory/Agent/SNMP/MibSupport/Digi.pm
@@ -27,7 +27,7 @@ sub getFirmware {
     my $device = $params{device};
     my $snmp   = $params{snmp} || $device->{snmp};
 
-    return $snmp->get('.1.3.6.1.4.1.16378.10000.3.16.0');
+    return $snmp->get(sarianSystem . '.16.0');
 }
 
 sub getSerial {
@@ -36,7 +36,7 @@ sub getSerial {
     my $device = $params{device};
     my $snmp   = $params{snmp} || $device->{snmp};
 
-    return $snmp->get('.1.3.6.1.4.1.16378.10000.3.15.0');
+    return $snmp->get(sarianSystem . '.15.0');
 }
 
 sub run {

--- a/lib/FusionInventory/Agent/SNMP/MibSupport/Digi.pm
+++ b/lib/FusionInventory/Agent/SNMP/MibSupport/Digi.pm
@@ -3,49 +3,42 @@ package FusionInventory::Agent::SNMP::MibSupport::Digi;
 use strict;
 use warnings;
 
-use base 'FusionInventory::Agent::SNMP::MibSupport';
+use parent 'FusionInventory::Agent::SNMP::MibSupportTemplate';
 
 # Constants extracted from Digi Sarian-Monitor.mib
 use constant    sarianMonitor   => ".1.3.6.1.4.1.16378.10000" ;
 use constant    sarianGPRS      => sarianMonitor . ".2" ;
 use constant    sarianSystem    => sarianMonitor . ".3" ;
 
-sub mibSupport {
-    return [
-        {
-            name    => "sarianMonitor",
-            oid     => sarianMonitor
-        }
-    ];
-}
+our $mibSupport = [
+    {
+        name    => "sarianMonitor",
+        oid     => sarianMonitor
+    }
+];
 
+# Supported values start from index 1
 my @gprsNetworkTechnology = qw(- unknown gprs edge umts hsdpa hsupa hspa lte);
 
 sub getFirmware {
-    my (%params) = @_;
+    my ($self) = @_;
 
-    my $device = $params{device};
-    my $snmp   = $params{snmp} || $device->{snmp};
-
-    return $snmp->get(sarianSystem . '.16.0');
+    return $self->get(sarianSystem . '.16.0');
 }
 
 sub getSerial {
-    my (%params) = @_;
+    my ($self) = @_;
 
-    my $device = $params{device};
-    my $snmp   = $params{snmp} || $device->{snmp};
-
-    return $snmp->get(sarianSystem . '.15.0');
+    return $self->get(sarianSystem . '.15.0');
 }
 
 sub run {
-    my (%params) = @_;
+    my ($self) = @_;
 
-    my $device = $params{device};
-    my $snmp   = $params{snmp} || $device->{snmp};
+    my $device = $self->device
+        or return;
 
-    my $sarianSystem = $snmp->walk(sarianSystem);
+    my $sarianSystem = $device->walk(sarianSystem);
 
     # Handle modem Digi private OIDs if found
     if ($sarianSystem) {
@@ -57,7 +50,7 @@ sub run {
         };
 
         # Handle SIM card looking for GRPS status
-        my $sarianGPRS = $snmp->walk(sarianGPRS);
+        my $sarianGPRS = $device->walk(sarianGPRS);
         if ($sarianGPRS) {
             my $simcard = {
                 IMSI    => $sarianGPRS->{'21.0'}, # gprsIMSI

--- a/lib/FusionInventory/Agent/SNMP/MibSupport/iLO.pm
+++ b/lib/FusionInventory/Agent/SNMP/MibSupport/iLO.pm
@@ -1,0 +1,115 @@
+package FusionInventory::Agent::SNMP::MibSupport::iLO;
+
+use strict;
+use warnings;
+
+use parent 'FusionInventory::Agent::SNMP::MibSupportTemplate';
+
+use FusionInventory::Agent::Tools;
+use FusionInventory::Agent::Tools::SNMP;
+
+# Constants extracted from Compaq cpqsm2.mib, as said in mib:
+# Implementation of the cpqSm2Cntrl group is mandatory for all agents
+# supporting the Remote Insight/Integrated Lights-Out MIB.
+# All Compaq iLO sysobjectid starts with .1.3.6.1.4.1.232.9.4
+use constant    compaq      => '.1.3.6.1.4.1.232' ;
+use constant    cpqSm2Cntrl => compaq . '.9.2.2' ;
+use constant    cpqSm2Nic   => compaq . '.9.2.5' ;
+
+our $mibSupport = [
+    {
+        name        => "cpqsm2",
+        sysobjectid => qr/^\.1\.3\.6\.1\.4\.1\.232\.9\.4/
+    }
+];
+
+sub getFirmware {
+    my ($self) = @_;
+
+    return $self->get(cpqSm2Cntrl . '.2.0');
+}
+
+sub getFirmwareDate {
+    my ($self) = @_;
+
+    return $self->get(cpqSm2Cntrl . '.1.0');
+}
+
+sub getSerial {
+    my ($self) = @_;
+
+    return $self->get(cpqSm2Cntrl . '.15.0');
+}
+
+sub getMacAddress {
+    my ($self) = @_;
+
+    my $cpqSm2NicConfigEntry = $self->_cpqSm2NicConfigEntry();
+    return unless ref($cpqSm2NicConfigEntry) eq 'ARRAY' && @{$cpqSm2NicConfigEntry};
+
+    return $cpqSm2NicConfigEntry->[3];
+}
+
+sub getIp {
+    my ($self) = @_;
+
+    my $cpqSm2NicConfigEntry = $self->_cpqSm2NicConfigEntry();
+    return unless ref($cpqSm2NicConfigEntry) eq 'ARRAY' && @{$cpqSm2NicConfigEntry};
+
+    return $cpqSm2NicConfigEntry->[4];
+}
+
+# TODO: Report server GUID so it is possible to link iLO to related host
+#sub _getServerGUID {
+#    my ($self) = @_;
+#
+#    return $self->get(cpqSm2Cntrl . '.26.0');
+#}
+
+my $sm2seq;
+# Handle cached cpqSm2NicConfigEntry sequence to limit walk during netinventory
+sub _cpqSm2NicConfigEntry {
+    my ($self) = @_;
+
+    return $sm2seq ?
+        $sm2seq : $sm2seq = $self->getSequence(cpqSm2Nic . '.1.1');
+}
+
+sub run {
+    my ($self) = @_;
+
+    my $device = $self->device
+        or return;
+
+    my $cpqSm2NicConfigEntry = $self->_cpqSm2NicConfigEntry();
+    return unless ref($cpqSm2NicConfigEntry) eq 'ARRAY' && @{$cpqSm2NicConfigEntry};
+
+    my @status = qw(- 2 1 2);
+
+    my $port = {
+        IFNUMBER        => 1,
+        IFDESCR         => getCanonicalString($cpqSm2NicConfigEntry->[1]),
+        MAC             => getCanonicalMacAddress($cpqSm2NicConfigEntry->[3]),
+        IFSTATUS        => $status[getCanonicalConstant($cpqSm2NicConfigEntry->[6])] || '2',
+        IFPORTDUPLEX    => getCanonicalConstant($cpqSm2NicConfigEntry->[7]),
+        IFSPEED         => getCanonicalConstant($cpqSm2NicConfigEntry->[8]) * 1000,
+        IFMTU           => getCanonicalConstant($cpqSm2NicConfigEntry->[11]),
+        IPS             => {
+            IP  => [ $cpqSm2NicConfigEntry->[4] ]
+        }
+    };
+
+    $device->addPort( 1 => $port );
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Inventory module for Digi modems and associated sim cards & firmwares
+
+=head1 DESCRIPTION
+
+The module adds SIMCARDS, MODEMS & FIRMWARES support for Digi devices

--- a/lib/FusionInventory/Agent/SNMP/MibSupportTemplate.pm
+++ b/lib/FusionInventory/Agent/SNMP/MibSupportTemplate.pm
@@ -1,0 +1,132 @@
+package FusionInventory::Agent::SNMP::MibSupportTemplate;
+
+use strict;
+use warnings;
+
+#use parent 'FusionInventory::Agent::SNMP::MibSupportTemplate';
+
+# define here constants as defined in related mib
+use constant    enterprises     => '.1.3.6.1.4.1' ;
+#use constant   sectionOID      => enterprises . '.XYZ';
+#use constant   valueOID        => oidSection . '.xyz.abc';
+#use constant   mibOID          => oidSection . '.x.y.z';
+
+our $mibSupport = [
+    # Example of mib support by sysobjectid matching
+    #{
+    #    name        => "mibName",
+    #    sysobjectid => qr/^\.1\.3\.6\.1\.4\.1\.ENTREPRISE\.X\.Y/
+    #},
+    # Example of mib support by checking snmp agent exposed mib support
+    # via sysORID entries
+    #{
+    #    name    => "mibName",
+    #    oid     => mibOID
+    #}
+];
+
+sub new {
+    my ($class, %params) = @_;
+
+    return unless $params{device};
+
+    my $self = {
+        _device => $params{device}
+    };
+
+    bless $self, $class;
+
+    return $self;
+}
+
+sub device {
+    my ($self) = @_;
+
+    return $self->{_device};
+}
+
+sub get {
+    my ($self, $oid) = @_;
+
+    return $self->{_device} && $self->{_device}->get($oid);
+}
+
+sub walk {
+    my ($self, $oid) = @_;
+
+    return $self->{_device} && $self->{_device}->walk($oid);
+}
+
+sub getSequence {
+    my ($self, $oid) = @_;
+
+    return unless $self->{_device};
+
+    my $walk = $self->{_device}->walk($oid);
+
+    return unless $walk;
+
+    return [
+        map { $walk->{$_} }
+        sort  { $a <=> $b }
+        keys %$walk
+    ];
+}
+
+sub getFirmware {
+    #my ($self) = @_;
+
+    #return $self->get(sectionOID . '.X.A');
+}
+
+sub getFirmwareDate {
+    #my ($self) = @_;
+
+    #return $self->get(sectionOID . '.X.B');
+}
+
+sub getSerial {
+    #my ($self) = @_;
+
+    #return $self->get(sectionOID . '.X.C');
+}
+
+sub getMacAddress {
+    #my ($self) = @_;
+
+    #return $self->get(sectionOID . '.X.D');
+}
+
+sub getIp {
+    #my ($self) = @_;
+
+    #return $self->get(sectionOID . '.X.E');
+}
+
+sub run {
+    #my ($self) = @_;
+
+    #my $device = $self->device
+    #    or return;
+
+    #my $other_firmware = {
+    #    NAME            => 'XXX Device',
+    #    DESCRIPTION     => 'XXX ' . $self->get(sectionOID . '.X.D') .' device',
+    #    TYPE            => 'Device type',
+    #    VERSION         => $self->get(sectionOID . '.X.D'),
+    #    MANUFACTURER    => 'XXX'
+    #};
+    #$device->addFirmware($other_firmware);
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Parent/Template class for inventory module
+
+=head1 DESCRIPTION
+
+Base class used for Mib support

--- a/lib/FusionInventory/Agent/SNMP/Mock.pm
+++ b/lib/FusionInventory/Agent/SNMP/Mock.pm
@@ -14,6 +14,7 @@ my %prefixes = (
     'SNMPv2-MIB::sysContact'            => '.1.3.6.1.2.1.1.4',
     'SNMPv2-MIB::sysName'               => '.1.3.6.1.2.1.1.5',
     'SNMPv2-MIB::sysLocation'           => '.1.3.6.1.2.1.1.6',
+    'SNMPv2-MIB::sysORID'               => '.1.3.6.1.2.1.1.9.1.2',
     'SNMPv2-SMI::mib-2'                 => '.1.3.6.1.2.1',
     'SNMPv2-SMI::enterprises'           => '.1.3.6.1.4.1',
     'IF-MIB::ifIndex'                   => '.1.3.6.1.2.1.2.2.1.1',

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -403,8 +403,8 @@ sub _getDevice {
     # Find device serial number
     $device->setSerial();
 
-    my $firmware = _getFirmware($snmp, $device->{TYPE});
-    $device->{FIRMWARE} = $firmware if $firmware;
+    # Find device firmware
+    $device->setFirmware();
 
     my $results = $snmp->walk('.1.3.6.1.2.1.4.20.1.1');
     $device->{IPS}->{IP} =  [
@@ -502,30 +502,6 @@ sub _loadSysObjectIDDatabase {
     }
 
     close $handle;
-}
-
-sub _getFirmware {
-    my ($snmp, $type) = @_;
-
-    my $entPhysicalSoftwareRev = $snmp->get_first('.1.3.6.1.2.1.47.1.1.1.1.10');
-    return $entPhysicalSoftwareRev if $entPhysicalSoftwareRev;
-
-    my $entPhysicalFirmwareRev = $snmp->get_first('.1.3.6.1.2.1.47.1.1.1.1.9');
-    return $entPhysicalFirmwareRev if $entPhysicalFirmwareRev;
-
-    # vendor specific OIDs
-    my @oids = (
-        '.1.3.6.1.4.1.9.9.25.1.1.1.2.5',         # Cisco / IOS
-        '.1.3.6.1.4.1.248.14.1.1.2.0',           # Hirschman MIB
-        '.1.3.6.1.4.1.2636.3.40.1.4.1.1.1.5.0',  # Juniper-MIB
-    );
-    foreach my $oid (@oids) {
-        my $value = $snmp->get($oid);
-        next unless $value;
-        return getCanonicalString($value);
-    }
-
-    return;
 }
 
 sub _getMacAddress {

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -8,12 +8,12 @@ use English qw(-no_match_vars);
 
 use FusionInventory::Agent::Tools;
 use FusionInventory::Agent::Tools::Network;
+use FusionInventory::Agent::Tools::SNMP;
 use FusionInventory::Agent::SNMP::Device;
 
 our @EXPORT = qw(
     getDeviceInfo
     getDeviceFullInfo
-    getCanonicalString
 );
 
 my %types = (
@@ -978,30 +978,6 @@ sub _getCanonicalMacAddress {
 
     return if $result eq '00:00:00:00:00:00';
     return lc($result);
-}
-
-sub getCanonicalString {
-    my ($value) = @_;
-
-    $value = hex2char($value);
-    return unless defined $value;
-
-    # unquote string
-    $value =~ s/^\\?["']//;
-    $value =~ s/\\?["']$//;
-
-    return unless defined $value;
-
-    # Be sure to work on utf-8 string
-    $value = getUtf8String($value);
-
-    # reduce linefeeds which can be found in descriptions or comments
-    $value =~ s/\p{Control}+\n/\n/g;
-
-    # truncate after first invalid character but keep newline as valid
-    $value =~ s/[^\p{Print}\n].*$//;
-
-    return $value;
 }
 
 sub _getCanonicalMemory {

--- a/lib/FusionInventory/Agent/Tools/SNMP.pm
+++ b/lib/FusionInventory/Agent/Tools/SNMP.pm
@@ -1,0 +1,72 @@
+package FusionInventory::Agent::Tools::SNMP;
+
+use strict;
+use warnings;
+use base 'Exporter';
+
+use FusionInventory::Agent::Tools;
+
+our @EXPORT = qw(
+    getCanonicalSerialNumber
+    getCanonicalString
+);
+
+sub getCanonicalSerialNumber {
+    my ($value) = @_;
+
+    $value = hex2char($value);
+    return unless $value;
+
+    $value =~ s/[[:^print:]]//g;
+    $value =~ s/^\s+//;
+    $value =~ s/\s+$//;
+    $value =~ s/\.{2,}//g;
+    return unless $value;
+
+    return $value;
+}
+
+sub getCanonicalString {
+    my ($value) = @_;
+
+    $value = hex2char($value);
+    return unless defined $value;
+
+    # unquote string
+    $value =~ s/^\\?["']//;
+    $value =~ s/\\?["']$//;
+
+    return unless defined $value;
+
+    # Be sure to work on utf-8 string
+    $value = getUtf8String($value);
+
+    # reduce linefeeds which can be found in descriptions or comments
+    $value =~ s/\p{Control}+\n/\n/g;
+
+    # truncate after first invalid character but keep newline as valid
+    $value =~ s/[^\p{Print}\n].*$//;
+
+    return $value;
+}
+
+1;
+__END__
+
+=head1 NAME
+
+FusionInventory::Agent::Tools::SNMP - SNMP Hardware-related functions
+
+=head1 DESCRIPTION
+
+This module provides some hardware-related functions for SNMP devices.
+
+=head1 FUNCTIONS
+
+=head2 getCanonicalSerialNumber($serial)
+
+return a clean serial number string.
+
+=head2 getCanonicalString($string)
+
+return a clean generic string.

--- a/resources/walks/sample4.result
+++ b/resources/walks/sample4.result
@@ -2,6 +2,13 @@
 <REQUEST>
   <CONTENT>
     <DEVICE>
+      <FIRMWARES>
+        <DESCRIPTION>device firmware</DESCRIPTION>
+        <MANUFACTURER>Hewlett-Packard</MANUFACTURER>
+        <NAME>ProCurve 5406zl (J8697A)</NAME>
+        <TYPE>device</TYPE>
+        <VERSION>K.15.04.0015m</VERSION>
+      </FIRMWARES>
       <INFO>
         <COMMENTS>ProCurve J8697A Switch 5406zl, revision K.15.04.0015m, ROM K.15.28 (/ws/swbuildm/ec_rel_charleston_qaoff/code/build/btm(ec_rel_</COMMENTS>
         <CONTACT>systeme@example.com</CONTACT>

--- a/t/agent/tools/hardware.t
+++ b/t/agent/tools/hardware.t
@@ -278,7 +278,6 @@ cmp_deeply(
         TYPE         => 'NETWORKING',
         MANUFACTURER => 'Qlogic',
         MODEL        => 'SANbox 5602 FC Switch',
-        EXTMOD       => 'Qlogic'
     },
     'getDeviceInfo() with sysobjectid and extmod'
 );

--- a/t/agent/tools/hardware.t
+++ b/t/agent/tools/hardware.t
@@ -8,6 +8,7 @@ use Test::More;
 
 use FusionInventory::Agent::SNMP::Mock;
 use FusionInventory::Agent::Tools::Hardware;
+use FusionInventory::Agent::Tools::SNMP;
 
 my @mac_tests = (
     [ 'd2:05:a8:6c:26:d5' , 'd2:05:a8:6c:26:d5' ],
@@ -220,7 +221,7 @@ plan tests =>
 
 foreach my $test (@mac_tests) {
     is(
-        FusionInventory::Agent::Tools::Hardware::_getCanonicalMacAddress($test->[0]),
+        FusionInventory::Agent::Tools::SNMP::getCanonicalMacAddress($test->[0]),
         $test->[1],
         "$test->[0] normalisation"
     );


### PR DESCRIPTION
sysORID OID entries can be used by devices to show which MIB the device supports
This PR adds the sysORID support to activate dedicated module. It can be a better and more reliable EXTMOD replacement as EXTMOD is only activated by sysocject.ids file update. This means any new device can activate the module even if it is not known in sysobject.ids.

The new FusionInventory::Agent::SNMP::Device also introduces the MODEMS/FIRMWARES/SIMCARDS spec support.

As a good example, I added a dedicated Digi module which adds MODEMS and related FIRMWARES infos as Digi devices show it support sarianMonitor MIB.

This PR is also an invitation to refactor SNMP device support around FusionInventory::Agent::SNMP::Device class