### PR TITLE
2.4.x+solaris drives fix

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/Solaris/Drives.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Solaris/Drives.pm
@@ -53,6 +53,8 @@ sub doInventory {
 
     # add filesystems to the inventory
     foreach my $filesystem (@filesystems) {
+        # Skip if filesystem is lofs
+        next if $filesystem->{FILESYSTEM} eq 'lofs';
         $inventory->addEntry(
             section => 'DRIVES',
             entry   => $filesystem

--- a/lib/FusionInventory/Agent/Tools/Unix.pm
+++ b/lib/FusionInventory/Agent/Tools/Unix.pm
@@ -165,18 +165,23 @@ sub getFilesystemsFromDf {
         # depending on the df implementation, and how it is called
         # the filesystem type may appear as second colum, or be missing
         # in the second case, it has to be given by caller
-        my ($filesystem, $total, $free, $type);
+        my ($filesystem, $total, $used, $free, $type);
         if ($headers[1] eq 'Type') {
             $filesystem = $infos[1];
             $total      = $infos[2];
+            $used       = $infos[3];
             $free       = $infos[4];
             $type       = $infos[6];
         } else {
             $filesystem = $params{type};
             $total      = $infos[1];
+            $used       = $infos[2];
             $free       = $infos[3];
             $type       = $infos[5];
         }
+
+        # Fix total for zfs under Solaris
+        $total = $used + $free if (!$total && ($used || $free));
 
         # skip some virtual filesystems
         next if $total !~ /^\d+$/ || $total == 0;

--- a/resources/solaris/df/zfs-samples
+++ b/resources/solaris/df/zfs-samples
@@ -1,0 +1,14 @@
+Filesystem            kbytes    used   avail capacity  Mounted on
+/                          0 6939073 15641400    31%    /
+/dev                 22580473 6939073 15641400    31%    /dev
+Z_FS_DATAPOOL/Z_FS_LV_DUMP       0   23468 471381611     1%    /dump
+Z_FS_DATAPOOL/lv_kba       0      43  524244     1%    /kba
+Z_FS_DATAPOOL/Z_FS_LV_ORACLE       0    5123 471381611     1%    /oracle
+proc                       0       0       0     0%    /proc
+ctfs                       0       0       0     0%    /system/contract
+mnttab                     0       0       0     0%    /etc/mnttab
+objfs                      0       0       0     0%    /system/object
+swap                 65666032     368 65665664     1%    /etc/svc/volatile
+fd                         0       0       0     0%    /dev/fd
+swap                 65666400     736 65665664     1%    /tmp
+swap                 65665736      72 65665664     1%    /var/run

--- a/resources/solaris/mount/zfs-samples
+++ b/resources/solaris/mount/zfs-samples
@@ -1,0 +1,13 @@
+/ on / type zfs read/write/setuid/devices/nonbmand/exec/xattr/atime/dev=4010004 on Thu Jul 16 16:32:15 2015
+/dev on /dev type lofs read/write/setuid/devices/zonedevfs/dev=55c0003 on Thu Jul 16 16:33:05 2015
+Z_FS_DATAPOOL/Z_FS_LV_DUMP on /dump type zfs read/write/setuid/devices/nonbmand/exec/xattr/atime/dev=4010025 on Thu Jul 16 16:33:06 2015
+Z_FS_DATAPOOL/lv_kba on /kba type zfs read/write/setuid/devices/nonbmand/exec/xattr/atime/dev=4010026 on Thu Jul 16 16:33:06 2015
+Z_FS_DATAPOOL/Z_FS_LV_ORACLE on /oracle type zfs read/write/setuid/devices/nonbmand/exec/xattr/atime/dev=4010027 on Thu Jul 16 16:33:06 2015
+proc on /proc type proc read/write/setuid/nodevices/zone=FS/dev=5280004 on Thu Jul 16 16:33:08 2015
+ctfs on /system/contract type ctfs read/write/setuid/nodevices/zone=FS/dev=5240002 on Thu Jul 16 16:33:08 2015
+mnttab on /etc/mnttab type mntfs read/write/setuid/nodevices/zone=FS/dev=52c0005 on Thu Jul 16 16:33:08 2015
+objfs on /system/object type objfs read/write/setuid/nodevices/zone=FS/dev=5340002 on Thu Jul 16 16:33:08 2015
+swap on /etc/svc/volatile type tmpfs read/write/setuid/nodevices/xattr/zone=FS/dev=5300007 on Thu Jul 16 16:33:08 2015
+fd on /dev/fd type fd read/write/setuid/nodevices/zone=FS/dev=54c0005 on Thu Jul 16 16:33:11 2015
+swap on /tmp type tmpfs read/write/setuid/nodevices/xattr/zone=FS/dev=530000b on Thu Jul 16 16:33:11 2015
+swap on /var/run type tmpfs read/write/setuid/nodevices/xattr/zone=FS/dev=530000c on Thu Jul 16 16:33:11 2015

--- a/t/tasks/inventory/solaris/drives.t
+++ b/t/tasks/inventory/solaris/drives.t
@@ -1,0 +1,80 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use lib 't/lib';
+
+use Test::Deep;
+use Test::Exception;
+use Test::More;
+use Test::NoWarnings;
+
+use FusionInventory::Test::Inventory;
+use FusionInventory::Agent::Task::Inventory::Solaris::Drives;
+
+my %tests = (
+    'zfs-samples' => [
+        {
+            FILESYSTEM  => 'zfs',
+            FREE        => 15274,
+            TOTAL       => 22051,
+            TYPE        => '/',
+            VOLUMN      => '/'
+        },
+        {
+            FILESYSTEM  => 'zfs',
+            FREE        => 460333,
+            TOTAL       => 460356,
+            TYPE        => '/dump',
+            VOLUMN      => 'Z_FS_DATAPOOL/Z_FS_LV_DUMP'
+        },
+        {
+            FILESYSTEM  => 'zfs',
+            FREE        => 511,
+            TOTAL       => 511,
+            TYPE        => '/kba',
+            VOLUMN      => 'Z_FS_DATAPOOL/lv_kba'
+        },
+        {
+            FILESYSTEM  => 'zfs',
+            FREE        => 460333,
+            TOTAL       => 460338,
+            TYPE        => '/oracle',
+            VOLUMN      => 'Z_FS_DATAPOOL/Z_FS_LV_ORACLE'
+        },
+        {
+            FILESYSTEM  => 'swap',
+            FREE        => 64126,
+            TOTAL       => 64126,
+            TYPE        => '/etc/svc/volatile',
+            VOLUMN      => 'swap'
+        },
+        {
+            FILESYSTEM  => 'swap',
+            FREE        => 64126,
+            TOTAL       => 64127,
+            TYPE        => '/tmp',
+            VOLUMN      => 'swap'
+        },
+        {
+            FILESYSTEM  => 'swap',
+            FREE        => 64126,
+            TOTAL       => 64126,
+            TYPE        => '/var/run',
+            VOLUMN      => 'swap'
+        }
+    ],
+);
+
+plan tests => (scalar keys %tests) + 1;
+
+foreach my $test (keys %tests) {
+    my $inventory = FusionInventory::Test::Inventory->new();
+    FusionInventory::Agent::Task::Inventory::Solaris::Drives::doInventory(
+        inventory   => $inventory,
+        file        => "resources/solaris/df/$test",
+        df_version  => $test,
+        mount_res   => "resources/solaris/mount/$test"
+    );
+    cmp_deeply($inventory->getSection('DRIVES'), $tests{$test}, "$test: parsing");
+}


### PR DESCRIPTION
df command on Solaris reports 0 as total sometime and so Drives module was skipping file systems
This PR fixes the problem and introduces a new unittest.