### PR TITLE
Force command to also timeout

### DIFF
--- a/Changes
+++ b/Changes
@@ -13,6 +13,7 @@ core:
   'use parent' and as fields pragma is not used (see 'base' man)
 * Logger refactoring: no more an Exporter based class to simplify its usage and
   as Logger object should be commonly shared everywhere it is used.
+* Fix command run to also time out while an alarm has been set
 * Few code refactoring
 
 inventory:
@@ -22,6 +23,7 @@ inventory:
 * Fix #349: Include last logged user as usual computer user on win32 platform
 * Linux distro: Add support for reading os-release file and removing LSB support
 * Fix Solaris drives df output parsing adding better zfs handling
+* Make backend-collect-timeout working even while waiting on command output
 
 netdiscovery/netinventory:
 * Bump NetDiscovery & NetInventory task version to 2.4


### PR DESCRIPTION
This fix a bug where an inventory can be blocked if a command is waiting forever.

To reproduce, from the source base folder without the patch applied, try the following commandline:
```
time perl -Ilib -e 'use FusionInventory::Agent::Logger; use FusionInventory::Agent::Tools; $logger = FusionInventory::Agent::Logger->new(debug => 2); sub test { print "waiting...\n"; @lines = getAllLines(command => "cat", logger => $logger); print "done\n"; }; runFunction(module => "main", function => "test", timeout => 5, logger => $logger ); print STDERR "DONE\n";'
```
Even if timeout to runFunction is set to 5 seconds, the `cat` command expects input on stdin and blocks the perl script. You can then only stop the process by breaking process input pressing CTRL+C.

After the patch is applied, the command reports the expected output while reaching the timeout.