### PR TITLE
Remove space for color consumable in XML tag

### DIFF
--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -718,6 +718,8 @@ sub _setPrinterProperties {
             my $color;
             if ($color_id) {
                 $color = getCanonicalString($colors->{$color_id});
+                # remove space and following char, XML tag does not accept space
+                $color =~ s/\s.*$//;
                 if (!$color) {
                     $logger->debug("invalid color ID $color_id") if $logger;
                     next;


### PR DESCRIPTION
If an XML netinventory printer contains a space in fail to import in glpi
`<CARTRIDGEMAGENTA INK>91</CARTRIDGEMAGENTA INK>`

`  plugins/fusioninventory/front/communication.php:93
PluginFusioninventoryCommunication->handleOCSCommunication()
  plugins/fusioninventory/index.php:59               include_once()
2017-12-04 16:19:42 [9@srv-glpi]
  *** PHP Warning(2): simplexml_load_string():
&lt;CARTRIDGEMAGENTA INK&gt;91&lt;/CARTRIDGEMAGENTA INK&gt;
  Backtrace :
  :
  ...fusioninventory/inc/communication.class.php:433 simplexml_load_string()
  plugins/fusioninventory/front/communication.php:93
PluginFusioninventoryCommunication->handleOCSCommunication()
  plugins/fusioninventory/index.php:59               include_once()
2017-12-04 16:19:42 [9@srv-glpi]
  *** PHP Warning(2): simplexml_load_string():
                           ^
  Backtrace :
  :
  ...fusioninventory/inc/communication.class.php:433 simplexml_load_string()
  plugins/fusioninventory/front/communication.php:93
PluginFusioninventoryCommunication->handleOCSCommunication()
  plugins/fusioninventory/index.php:59               include_once()
2017-12-04 16:19:42 [9@srv-glpi]
  *** PHP Warning(2): simplexml_load_string(): Entity: line 9: parser
error : Specification mandate value for attribute INK`

FIX: remove space and following char suggested by @g-bougard 
