### PR TITLE
Keep first MAC address found while discovering

### DIFF
--- a/Changes
+++ b/Changes
@@ -28,13 +28,14 @@ inventory:
 * Support ASM filesystems on Oracle Grid
 
 netdiscovery/netinventory:
-* Bump NetDiscovery & NetInventory task version to 2.4
+* Bump NetDiscovery & NetInventory task version to 2.5
 * Added section support for MODEMS, SIMCARDS & FIRMWARES
 * Added new detection algorithm based on exposed device supported MIB (sysORID list)
   and/or sysObjectID
 * Added support for HP iLO cards
 * Added support for Digi devices with enhanced MODEMS, SIMCARDS & FIRMWARES support
 * Updated sysobject.ids with a lot of new devices support
+* Keep first MAC address found while discovering
 
 deploy:
 * Bump Deploy task version to 2.5

--- a/bin/fusioninventory-netinventory
+++ b/bin/fusioninventory-netinventory
@@ -77,6 +77,7 @@ if ($options->{file}) {
     push @devices, {
         ID           => $id++,
         FILE         => $_,
+        IP           => shift @{$options->{host}},
         AUTHSNMP_ID  => 1,
         MODELSNMP_ID => 1
     } foreach @{$options->{file}};

--- a/lib/FusionInventory/Agent/SNMP/Device.pm
+++ b/lib/FusionInventory/Agent/SNMP/Device.pm
@@ -289,6 +289,14 @@ sub setMacAddress {
     # interfaces list with defined ip to use as filter to select shorter mac address list
     my $ips = $self->walk('.1.3.6.1.2.1.4.20.1.2');
 
+    # If peer adress is known, get mac from it
+    my $peer = $self->{snmp}->peer_address();
+    if ($peer && $ips->{$peer} && $addresses->{$ips->{$peer}}) {
+        $address = getCanonicalMacAddress($addresses->{$ips->{$peer}});
+        return $self->{MAC} = $address
+            if $address && $address =~ /^$mac_address_pattern$/;
+    }
+
     my @all_mac_addresses = ();
 
     # Try first to obtain shorter mac address list using ip interface list filter

--- a/lib/FusionInventory/Agent/SNMP/Live.pm
+++ b/lib/FusionInventory/Agent/SNMP/Live.pm
@@ -172,6 +172,16 @@ sub walk {
     return $values;
 }
 
+sub peer_address {
+    my ($self) = @_;
+
+    # transport() API is not documented in Net::SNMP
+    my $transport = $self->{session}->transport()
+        or return;
+
+    return $transport->peer_address();
+}
+
 1;
 __END__
 

--- a/lib/FusionInventory/Agent/SNMP/Mock.pm
+++ b/lib/FusionInventory/Agent/SNMP/Mock.pm
@@ -36,7 +36,9 @@ my %prefixes = (
 sub new {
     my ($class, %params) = @_;
 
-    my $self = {};
+    my $self = {
+        _ip => $params{ip}
+    };
     bless $self, $class;
 
     SWITCH: {
@@ -243,6 +245,12 @@ sub _getSanitizedValue {
     }
 
     return $value;
+}
+
+sub peer_address {
+    my ($self) = @_;
+
+    return $self->{_ip};
 }
 
 1;

--- a/lib/FusionInventory/Agent/Task/NetDiscovery.pm
+++ b/lib/FusionInventory/Agent/Task/NetDiscovery.pm
@@ -322,40 +322,30 @@ sub _scanAddress {
     my $id     = threads->tid();
     $logger->debug("[thread $id] scanning $params{ip}:");
 
-    my $device = $self->_scanAddressByNmap(%params) || {};
-
-    foreach my $scannedDevice (
-        $self->_scanAddressByNetbios(%params),
-        $self->_scanAddressBySNMP(%params)
-    ) {
-        next unless $scannedDevice;
-        foreach my $key (keys(%{$scannedDevice})) {
-            # Don't override MAC if still set
-            next if ($key eq 'MAC' && $device->{MAC});
-            $device->{$key} = $scannedDevice->{$key};
-        }
-    }
+    my %device = (
+        $INC{'Net/SNMP.pm'}      ? $self->_scanAddressBySNMP(%params)    : (),
+        $INC{'Net/NBName.pm'}    ? $self->_scanAddressByNetbios(%params) : (),
+        $params{nmap_parameters} ? $self->_scanAddressByNmap(%params)    : ()
+    );
 
     # don't report anything without a minimal amount of information
     return unless
-        $device->{MAC}          ||
-        $device->{SNMPHOSTNAME} ||
-        $device->{DNSHOSTNAME}  ||
-        $device->{NETBIOSNAME};
+        $device{MAC}          ||
+        $device{SNMPHOSTNAME} ||
+        $device{DNSHOSTNAME}  ||
+        $device{NETBIOSNAME};
 
-    $device->{IP} = $params{ip};
+    $device{IP} = $params{ip};
 
-    if ($device->{MAC}) {
-        $device->{MAC} =~ tr/A-F/a-f/;
+    if ($device{MAC}) {
+        $device{MAC} =~ tr/A-F/a-f/;
     }
 
-    return $device;
+    return \%device;
 }
 
 sub _scanAddressByNmap {
     my ($self, %params) = @_;
-
-    return unless $params{nmap_parameters};
 
     my $device = _parseNmap(
         command => "nmap $params{nmap_parameters} $params{ip} -oX -"
@@ -368,13 +358,11 @@ sub _scanAddressByNmap {
         $device ? 'success' : 'no result'
     );
 
-    return $device;
+    return $device ? %$device : ();
 }
 
 sub _scanAddressByNetbios {
     my ($self, %params) = @_;
-
-    return unless $INC{'Net/NBName.pm'};
 
     my $nb = Net::NBName->new();
 
@@ -388,33 +376,31 @@ sub _scanAddressByNetbios {
     );
     return unless $ns;
 
-    my $device = {};
+    my %device;
     foreach my $rr ($ns->names()) {
         my $suffix = $rr->suffix();
         my $G      = $rr->G();
         my $name   = $rr->name();
         if ($suffix == 0 && $G eq 'GROUP') {
-            $device->{WORKGROUP} = getSanitizedString($name);
+            $device{WORKGROUP} = getSanitizedString($name);
         }
         if ($suffix == 3 && $G eq 'UNIQUE') {
-            $device->{USERSESSION} = getSanitizedString($name);
+            $device{USERSESSION} = getSanitizedString($name);
         }
         if ($suffix == 0 && $G eq 'UNIQUE') {
-            $device->{NETBIOSNAME} = getSanitizedString($name)
+            $device{NETBIOSNAME} = getSanitizedString($name)
                 unless $name =~ /^IS~/;
         }
     }
 
-    $device->{MAC} = $ns->mac_address();
-    $device->{MAC} =~ tr/-/:/;
+    $device{MAC} = $ns->mac_address();
+    $device{MAC} =~ tr/-/:/;
 
-    return $device;
+    return %device;
 }
 
 sub _scanAddressBySNMP {
     my ($self, %params) = @_;
-
-    return unless $INC{'Net/SNMP.pm'};
 
     foreach my $credential (@{$params{snmp_credentials}}) {
         my $device = $self->_scanAddressBySNMPReal(
@@ -435,7 +421,7 @@ sub _scanAddressBySNMP {
 
         if (ref $device eq 'HASH') {
             $device->{AUTHSNMP} = $credential->{ID};
-            return $device;
+            return %{$device};
         }
     }
 

--- a/lib/FusionInventory/Agent/Task/NetDiscovery/Version.pm
+++ b/lib/FusionInventory/Agent/Task/NetDiscovery/Version.pm
@@ -3,6 +3,6 @@ package FusionInventory::Agent::Task::NetDiscovery::Version;
 use strict;
 use warnings;
 
-use constant VERSION => "2.4";
+use constant VERSION => "2.5";
 
 1;

--- a/lib/FusionInventory/Agent/Task/NetInventory.pm
+++ b/lib/FusionInventory/Agent/Task/NetInventory.pm
@@ -285,6 +285,7 @@ sub _queryDevice {
         FusionInventory::Agent::SNMP::Mock->require();
         eval {
             $snmp = FusionInventory::Agent::SNMP::Mock->new(
+                ip   => $device->{IP},
                 file => $device->{FILE}
             );
         };

--- a/lib/FusionInventory/Agent/Task/NetInventory/Version.pm
+++ b/lib/FusionInventory/Agent/Task/NetInventory/Version.pm
@@ -3,6 +3,6 @@ package FusionInventory::Agent::Task::NetInventory::Version;
 use strict;
 use warnings;
 
-use constant VERSION => "2.4";
+use constant VERSION => "2.5";
 
 1;


### PR DESCRIPTION
This should avoid to reset to a wrong MAC at SNMP detection level.
This should fix cases where device is not imported while MAC doesn't match any more.