### PR TITLE
Linux daemon updates

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,9 +6,13 @@ core:
   logged in journal
 * Get rid of confdir setup in setup.pm
 * Update syslog name to fullname agent
-* Get rid of List::Util module dependency
+* Get rid of List::Util & Proc::PID::File module dependencies
 * Try to load more recent IDS database files if found in well-known places
-* Fixed daemon pid filename
+* Fixed default daemon pid filename
+* When --pidfile is used, don't permit to manually start daemon even in foreground
+  unless --pidfile parameter is different
+* Makes --pidfile filename optional to compute a default one
+* Check if we need to include libdir while daemonize
 * Class refactoring: Get rid of discouraged 'use base' syntax in favor of lighter
   'use parent' and as fields pragma is not used (see 'base' man)
 * Logger refactoring: no more an Exporter based class to simplify its usage and

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -45,7 +45,6 @@ recommends 'LWP::Protocol::https' => '0';
 
 if ($OSNAME ne 'MSWin32') {
     recommends 'Proc::Daemon'         => '0';
-    recommends 'Proc::PID::File'      => '0';
 } else {
     recommends 'Win32::Daemon'        => '0';
     recommends 'Win32::Unicode::File' => '0';

--- a/bin/fusioninventory-agent
+++ b/bin/fusioninventory-agent
@@ -47,7 +47,7 @@ GetOptions(
     'no-task=s',
     'no-p2p',
     'password|p=s',
-    'pidfile=s',
+    'pidfile:s',
     'proxy|P=s',
     'httpd-ip=s',
     'httpd-port=s',
@@ -637,11 +637,12 @@ Don't fork in background.
 
 This is only useful when running as a daemon.
 
-=item B<--pidfile>=I<FILE>
+=item B<--pidfile>[=I<FILE>]
 
-Store pid in I<FILE>.
+Store pid in I<FILE> or in default PID file.
 
-This is only useful when running as a daemon.
+This is only useful when running as a daemon and still not managed with a system
+service manager like systemd.
 
 =item B<--tag>=I<TAG>
 

--- a/lib/FusionInventory/Agent/Daemon.pm
+++ b/lib/FusionInventory/Agent/Daemon.pm
@@ -255,8 +255,8 @@ sub createDaemon {
             pid_file => $pidfile
         );
 
-        # Just is case Proc::PID::File is not installed, we should use Proc::Daemon
-        # API to check daemon status
+        # Use Proc::Daemon API to check daemon status but it always return false
+        # if pidfile is not used
         if ($daemon->Status()) {
             $logger->error("$PROVIDER Agent is already running, exiting...") if $logger;
             exit 1;


### PR DESCRIPTION
Get rid of Proc::PID::File - Fix #424.
Also make filename optional to --pidfile option.
Check against pid file only if --pidfile is used as service manager
like systemd doesn't expect with handle ourself to run or not.
Fix PID file checking even in foreground mode.
Be sure to keep libdir in @INC before daemonize.