### PR TITLE
2.4.x+netinventory updates

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,6 +9,7 @@ netdiscovery/netinventory:
  * Fix total printed pages counter in many case
  * Added total color pages counter support
 * Don't assume colors table was read: fixes black toner detection on many HP printers
+* Added Microtik devices support
 * Updated LLDP support
 
 2.4 Fri, 29 Dec 2017

--- a/Changes
+++ b/Changes
@@ -10,6 +10,7 @@ netdiscovery/netinventory:
  * Added total color pages counter support
 * Don't assume colors table was read: fixes black toner detection on many HP printers
 * Added Microtik devices support
+* Enhanced Epson printers support, including model name, serial number and firmwares
 * Updated LLDP support
 
 2.4 Fri, 29 Dec 2017

--- a/Changes
+++ b/Changes
@@ -8,6 +8,7 @@ netdiscovery/netinventory:
  * Get Serial number & firmware version
  * Fix total printed pages counter in many case
  * Added total color pages counter support
+* Don't assume colors table was read: fixes black toner detection on many HP printers
 * Updated LLDP support
 
 2.4 Fri, 29 Dec 2017

--- a/Changes
+++ b/Changes
@@ -2,7 +2,13 @@ Revision history for FusionInventory agent
 
 2.4.1 not released yet
 
-nothing changed yet
+netdiscovery/netinventory:
+* Bump NetDiscovery & NetInventory task version to 2.6
+* Added support for HP Net Peripheral, involving better HP printers inventory
+ * Get Serial number & firmware version
+ * Fix total printed pages counter in many case
+ * Added total color pages counter support
+* Updated LLDP support
 
 2.4 Fri, 29 Dec 2017
 core:

--- a/lib/FusionInventory/Agent/SNMP/Device.pm
+++ b/lib/FusionInventory/Agent/SNMP/Device.pm
@@ -196,12 +196,12 @@ sub setSerial {
     my ($self) = @_;
 
     my $serial =
+        # First try MIB Support mechanism
+        $self->getSerialByMibSupport()                         ||
         # Entity-MIB::entPhysicalSerialNum
         $self->{snmp}->get_first('.1.3.6.1.2.1.47.1.1.1.1.11') ||
         # Printer-MIB::prtGeneralSerialNumber
-        $self->{snmp}->get_first('.1.3.6.1.2.1.43.5.1.1.17') ||
-        # Try MIB Support mechanism
-        $self->getSerialByMibSupport();
+        $self->{snmp}->get_first('.1.3.6.1.2.1.43.5.1.1.17');
 
     if ( not defined $serial ) {
         # vendor specific OIDs
@@ -237,12 +237,12 @@ sub setFirmware {
     my ($self) = @_;
 
     my $firmware =
+        # First try to get firmware from MIB Support mechanism
+        $self->getFirmwareByMibSupport()                       ||
         # entPhysicalSoftwareRev
         $self->{snmp}->get_first('.1.3.6.1.2.1.47.1.1.1.1.10') ||
         # entPhysicalFirmwareRev
-        $self->{snmp}->get_first('.1.3.6.1.2.1.47.1.1.1.1.9')  ||
-        # firmware from supported mib
-        $self->getFirmwareByMibSupport();
+        $self->{snmp}->get_first('.1.3.6.1.2.1.47.1.1.1.1.9');
 
     if ( not defined $firmware ) {
         # vendor specific OIDs

--- a/lib/FusionInventory/Agent/SNMP/Device.pm
+++ b/lib/FusionInventory/Agent/SNMP/Device.pm
@@ -223,9 +223,14 @@ sub setSerial {
         }
     }
 
+    $serial = getCanonicalSerialNumber($serial);
+
     return unless $serial;
 
-    $self->{SERIAL} = getCanonicalSerialNumber($serial);
+    # Skip well-known invalid serial number
+    return if $serial =~ /^X+$/;
+
+    $self->{SERIAL} = $serial;
 }
 
 sub setFirmware {

--- a/lib/FusionInventory/Agent/SNMP/Device.pm
+++ b/lib/FusionInventory/Agent/SNMP/Device.pm
@@ -250,11 +250,11 @@ sub setFirmware {
             $firmware = $self->get($oid);
             last if defined $firmware;
         }
+        return unless defined $firmware;
     }
 
-    return unless defined $firmware;
-
     $firmware = getCanonicalString($firmware);
+
     return unless $firmware;
 
     # Set device firmware

--- a/lib/FusionInventory/Agent/SNMP/Device.pm
+++ b/lib/FusionInventory/Agent/SNMP/Device.pm
@@ -254,8 +254,11 @@ sub setFirmware {
 
     return unless defined $firmware;
 
+    $firmware = getCanonicalString($firmware);
+    return unless $firmware;
+
     # Set device firmware
-    $self->{FIRMWARE} = getCanonicalString($firmware);
+    $self->{FIRMWARE} = $firmware;
 
     # Also add firmware as device FIRMWARES
     $self->addFirmware({

--- a/lib/FusionInventory/Agent/SNMP/MibSupport/Epson.pm
+++ b/lib/FusionInventory/Agent/SNMP/MibSupport/Epson.pm
@@ -1,0 +1,69 @@
+package FusionInventory::Agent::SNMP::MibSupport::Epson;
+
+use strict;
+use warnings;
+
+use parent 'FusionInventory::Agent::SNMP::MibSupportTemplate';
+
+use FusionInventory::Agent::Tools;
+use FusionInventory::Agent::Tools::SNMP;
+
+use constant    epson   => '.1.3.6.1.4.1.1248' ;
+use constant    model   => epson  .'.1.2.2.1.1.1.2.1' ;
+use constant    serial  => epson  .'.1.2.2.1.1.1.5.1' ;
+use constant    fw_base => epson . '.1.2.2.2.1.1' ;
+
+our $mibSupport = [
+    {
+        name        => "epson-printer",
+        sysobjectid => getRegexpOidMatch(epson)
+    }
+];
+
+sub getSerial {
+    my ($self) = @_;
+
+    return $self->get(serial);
+}
+
+sub getModel {
+    my ($self) = @_;
+
+    return $self->get(model)
+}
+
+sub run {
+    my ($self) = @_;
+
+    my $device = $self->device
+        or return;
+
+    my $versions  = $self->walk(fw_base.'.2') || {};
+    my $names     = $self->walk(fw_base.'.3') || {};
+    my $firmwares = $self->walk(fw_base.'.4') || $names;
+    if ($firmwares) {
+        foreach my $index (keys(%{$firmwares})) {
+            next unless $versions->{$index};
+            my $firmware = {
+                NAME            => "Epson ".($names->{$index} || "printer"),
+                DESCRIPTION     => "Epson printer ".($names->{$index} || "firmware"),
+                TYPE            => "printer",
+                VERSION         => $versions->{$index},
+                MANUFACTURER    => "Epson"
+            };
+            $device->addFirmware($firmware);
+        }
+    }
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Inventory module for Epson Printers
+
+=head1 DESCRIPTION
+
+The module enhances Epson printers devices support.

--- a/lib/FusionInventory/Agent/SNMP/MibSupport/HPNetPeripheral.pm
+++ b/lib/FusionInventory/Agent/SNMP/MibSupport/HPNetPeripheral.pm
@@ -1,0 +1,126 @@
+package FusionInventory::Agent::SNMP::MibSupport::HPNetPeripheral;
+
+use strict;
+use warnings;
+
+use parent 'FusionInventory::Agent::SNMP::MibSupportTemplate';
+
+use FusionInventory::Agent::Tools;
+use FusionInventory::Agent::Tools::SNMP;
+
+# See HP-LASERJET-COMMON-MIB / JETDIRECT3-MIB
+use constant    hpPeripheral    => '.1.3.6.1.4.1.11.2.3.9' ; # hp.nm.system.net-peripheral
+use constant    hpNetPrinter    => hpPeripheral  .'.1' ;
+use constant    hpDevice        => hpPeripheral . '.4.2.1' ; # + netPML.netPMLmgmt.device
+
+use constant    gdStatusId      => hpNetPrinter . '.1.7.0' ;
+
+# System id
+use constant    systemId        => hpDevice . '.1.3' ;       # + system.id
+use constant    model_name      => systemId . '.2.0' ;
+use constant    serial_number   => systemId . '.3.0' ;
+use constant    fw_rom_datecode => systemId . '.5.0' ;
+use constant    fw_rom          => systemId . '.6.0' ;
+
+# Status print engine: status-prt-eng
+use constant    statusPrtEngine => hpDevice . '.4.1.2' ;
+use constant    totalEnginePageCount => statusPrtEngine . '.5.0' ;
+use constant    totalColorPageCount  => statusPrtEngine . '.7.0' ;
+use constant    duplexPageCount      => statusPrtEngine . '.22.0' ;
+
+my %counters = (
+    TOTAL   => totalEnginePageCount,
+    COLOR   => totalColorPageCount,
+    DUPLEX  => duplexPageCount
+);
+
+our $mibSupport = [
+    {
+        name        => "hp-peripheral",
+        sysobjectid => getRegexpOidMatch(hpPeripheral)
+    }
+];
+
+sub getFirmware {
+    my ($self) = @_;
+
+    my $device = $self->device
+        or return;
+
+    my $firmware = $self->_getClean(fw_rom);
+
+    # Eventually extract EEPROM revision from device description
+    if (!$firmware && $device->{DESCRIPTION}) {
+        foreach (split(/,+/, $device->{DESCRIPTION})) {
+            return $1 if /EEPROM\s+(\S+)/;
+        }
+    }
+
+    return $firmware;
+}
+
+sub getFirmwareDate {
+    my ($self) = @_;
+
+    return $self->_getClean(fw_rom_datecode);
+}
+
+sub getSerial {
+    my ($self) = @_;
+
+    return $self->get(serial_number);
+}
+
+sub getModel {
+    my ($self) = @_;
+
+    # Try first to get model if set in StatusId string
+    my $statusId = getCanonicalString($self->get(gdStatusId));
+    if ($statusId) {
+        foreach (split(/\s*;\s*/, $statusId)) {
+            return $1 if /^MODEL:\s*(.*)$/;
+        }
+    }
+
+    # Else try to get model from model-name string
+    return $self->_getClean(model_name);
+}
+
+sub run {
+    my ($self) = @_;
+
+    my $device = $self->device
+        or return;
+
+    # Update counters if still not found
+    foreach my $counter (keys %counters) {
+        next if $device->{PAGECOUNTERS} && $device->{PAGECOUNTERS}->{$counter};
+        my $count = $self->get($counters{$counter})
+            or next;
+        $device->{PAGECOUNTERS}->{$counter} = getCanonicalConstant($count);
+    }
+}
+
+sub _getClean {
+    my ($self, $oid) = @_;
+
+    my $clean_string = hex2char($self->get($oid));
+
+    return unless defined $clean_string;
+
+    $clean_string =~ s/[[:^print:]]//g;
+
+    return $clean_string;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Inventory module for HP Printers
+
+=head1 DESCRIPTION
+
+The module enhances HP printers devices support.

--- a/lib/FusionInventory/Agent/SNMP/MibSupport/Mikrotik.pm
+++ b/lib/FusionInventory/Agent/SNMP/MibSupport/Mikrotik.pm
@@ -1,0 +1,62 @@
+package FusionInventory::Agent::SNMP::MibSupport::Mikrotik;
+
+use strict;
+use warnings;
+
+use parent 'FusionInventory::Agent::SNMP::MibSupportTemplate';
+
+use FusionInventory::Agent::Tools;
+use FusionInventory::Agent::Tools::SNMP;
+
+# See MIKROTIK-MIB
+use constant    mikrotikExperimentalModule  => '.1.3.6.1.4.1.14988.1' ;
+use constant    mtxrSystem => mikrotikExperimentalModule  .'.1.7' ;
+
+use constant    mtxrSerialNumber    => mtxrSystem . '.3.0' ;
+use constant    mtxrFirmwareVersion => mtxrSystem . '.4.0' ;
+
+our $mibSupport = [
+    {
+        name        => "mikrotik",
+        sysobjectid => getRegexpOidMatch(mikrotikExperimentalModule)
+    }
+];
+
+sub getFirmware {
+    my ($self) = @_;
+
+    return $self->get(mtxrFirmwareVersion);
+}
+
+sub getSerial {
+    my ($self) = @_;
+
+    return $self->get(mtxrSerialNumber);
+}
+
+sub getModel {
+    my ($self) = @_;
+
+    my $device = $self->device
+        or return;
+
+    my $model;
+
+    # Extract model from device description for RouterOS based systems
+    ( $model ) = $device->{DESCRIPTION} =~ /^RouterOS\s+(.*)$/
+        if $device->{DESCRIPTION};
+
+    return $model;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Inventory module for Mikrotik devices
+
+=head1 DESCRIPTION
+
+The module fixes Mikrotik SerialNumber & Firmware version support.

--- a/lib/FusionInventory/Agent/SNMP/MibSupportTemplate.pm
+++ b/lib/FusionInventory/Agent/SNMP/MibSupportTemplate.pm
@@ -5,6 +5,8 @@ use warnings;
 
 #use parent 'FusionInventory::Agent::SNMP::MibSupportTemplate';
 
+#use FusionInventory::Agent::Tools::SNMP;
+
 # define here constants as defined in related mib
 use constant    enterprises     => '.1.3.6.1.4.1' ;
 #use constant   sectionOID      => enterprises . '.XYZ';
@@ -19,7 +21,7 @@ our $mibSupport = [
     #},
     #{
     #    name        => "mibName",
-    #    sysobjectid => first { qr/^$_/ } enterprises . '.ENTREPRISE.X.Y'
+    #    sysobjectid => getRegexpOidMatch(enterprises . '.ENTREPRISE.X.Y')
     #},
     # Example of mib support by checking snmp agent exposed mib support
     # via sysORID entries

--- a/lib/FusionInventory/Agent/SNMP/MibSupportTemplate.pm
+++ b/lib/FusionInventory/Agent/SNMP/MibSupportTemplate.pm
@@ -12,10 +12,14 @@ use constant    enterprises     => '.1.3.6.1.4.1' ;
 #use constant   mibOID          => oidSection . '.x.y.z';
 
 our $mibSupport = [
-    # Example of mib support by sysobjectid matching
+    # Examples of mib support by sysobjectid matching
     #{
     #    name        => "mibName",
     #    sysobjectid => qr/^\.1\.3\.6\.1\.4\.1\.ENTREPRISE\.X\.Y/
+    #},
+    #{
+    #    name        => "mibName",
+    #    sysobjectid => first { qr/^$_/ } enterprises . '.ENTREPRISE.X.Y'
     #},
     # Example of mib support by checking snmp agent exposed mib support
     # via sysORID entries
@@ -101,6 +105,12 @@ sub getIp {
     #my ($self) = @_;
 
     #return $self->get(sectionOID . '.X.E');
+}
+
+sub getModel {
+    #my ($self) = @_;
+
+    #return $self->get(sectionOID . '.X.F');
 }
 
 sub run {

--- a/lib/FusionInventory/Agent/Task/NetDiscovery/Version.pm
+++ b/lib/FusionInventory/Agent/Task/NetDiscovery/Version.pm
@@ -3,6 +3,6 @@ package FusionInventory::Agent::Task::NetDiscovery::Version;
 use strict;
 use warnings;
 
-use constant VERSION => "2.5";
+use constant VERSION => "2.6";
 
 1;

--- a/lib/FusionInventory/Agent/Task/NetInventory/Version.pm
+++ b/lib/FusionInventory/Agent/Task/NetInventory/Version.pm
@@ -3,6 +3,6 @@ package FusionInventory::Agent::Task::NetInventory::Version;
 use strict;
 use warnings;
 
-use constant VERSION => "2.5";
+use constant VERSION => "2.6";
 
 1;

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -1177,6 +1177,13 @@ sub _getLLDPInfo {
         my $sysname = getCanonicalString($lldpRemSysName->{$suffix});
         next unless ($sysdescr || $sysname);
 
+        # Skip unexpected suffix format (seen at least on mikrotik devices)
+        if ($suffix =~ /^\d+$/) {
+            $logger->debug2("LLDP support: skipping unsupported suffix interface $suffix")
+                if ($logger);
+            next;
+        }
+
         # Skip unsupported LldpChassisIdSubtype
         my $subtype = $ChassisIdSubType->{$suffix} || "n/a";
         unless ($subtype eq '4') {

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -674,7 +674,7 @@ sub _setPrinterProperties {
             $type = $consumable_types{$type_id};
         } else {
             # fallback on description
-            my $description = $descriptions->{$consumable_id};
+            my $description = getCanonicalString($descriptions->{$consumable_id});
             $type =
                 $description =~ /maintenance/i ? 'MAINTENANCEKIT' :
                 $description =~ /fuser/i       ? 'FUSERKIT'       :
@@ -683,8 +683,8 @@ sub _setPrinterProperties {
         }
 
         if (!$type) {
-            $logger->debug("unknown consumable type $type_id: ".
-                ($descriptions->{$consumable_id} || "no description")
+            $logger->debug("unknown consumable type $type_id: " .
+                (getCanonicalString($descriptions->{$consumable_id}) || "no description")
             ) if $logger;
             next;
         }
@@ -694,14 +694,16 @@ sub _setPrinterProperties {
             if ($color_id) {
                 $color = getCanonicalString($colors->{$color_id});
                 if (!$color) {
-                    $logger->debug("invalid color ID $color_id") if $logger;
+                    $logger->debug("invalid consumable color ID $color_id for : " .
+                        (getCanonicalString($descriptions->{$consumable_id}) || "no description")
+                    ) if $logger;
                     next;
                 }
                 # remove space and following char, XML tag does not accept space
                 $color =~ s/\s.*$//;
             } else {
                 # fallback on description
-                my $description = $descriptions->{$consumable_id};
+                my $description = getCanonicalString($descriptions->{$consumable_id});
                 $color =
                     $description =~ /cyan/i           ? 'cyan'    :
                     $description =~ /magenta/i        ? 'magenta' :

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -691,7 +691,7 @@ sub _setPrinterProperties {
 
         if ($type eq 'TONER' || $type eq 'DRUM' || $type eq 'CARTRIDGE' || $type eq 'DEVELOPER') {
             my $color;
-            if ($color_id) {
+            if ($colors && $color_id) {
                 $color = getCanonicalString($colors->{$color_id});
                 if (!$color) {
                     $logger->debug("invalid consumable color ID $color_id for : " .

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -1185,9 +1185,9 @@ sub _getLLDPInfo {
                     (getCanonicalString($mac) || "no chassis id") . ", " .
                     ($sysdescr || "no description");
                 if ($not_supported_subtype{$subtype}) {
-                    $logger->debug("LLDP info: skipping $not_supported_subtype{$subtype}: $info");
+                    $logger->debug("LLDP support: skipping $not_supported_subtype{$subtype}: $info");
                 } else {
-                    $logger->debug("LLDP info: ChassisId subtype $subtype not supported for <$info>, please report this issue");
+                    $logger->debug("LLDP support: ChassisId subtype $subtype not supported for <$info>, please report this issue");
                 }
             }
             next;

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -626,13 +626,13 @@ sub _setGenericProperties {
         next unless $value;
         # safety checks
         if (! exists $ports->{$value}) {
-            $logger->warning(
+            $logger->debug(
                 "unknown interface $value for IP address $suffix, ignoring"
             ) if $logger;
             next;
         }
         if ($suffix !~ /^$ip_address_pattern$/) {
-            $logger->error("invalid IP address $suffix") if $logger;
+            $logger->debug("invalid IP address $suffix") if $logger;
             next;
         }
         $ports->{$value}->{IP} = $suffix;
@@ -757,7 +757,7 @@ sub _setPrinterProperties {
         }
         next unless defined $value;
         if (!isInteger($value)) {
-            $logger->error("incorrect counter value $value, check $variable->{mapping} mapping") if $logger;
+            $logger->debug("incorrect counter value $value, check $variable->{mapping} mapping") if $logger;
             next;
         }
         $device->{PAGECOUNTERS}->{$key} = $value;
@@ -947,7 +947,7 @@ sub _addKnownMacAddresses {
     foreach my $port_id (keys %$mac_addresses) {
         # safety check
         if (! exists $ports->{$port_id}) {
-            $logger->error(
+            $logger->debug(
                 "invalid interface ID $port_id while setting known mac " .
                 "addresses, aborting"
             ) if $logger;
@@ -1045,8 +1045,8 @@ sub _setConnectedDevices {
         foreach my $interface_id (keys %$lldp_info) {
             # safety check
             if (! exists $ports->{$interface_id}) {
-                $logger->warning(
-                    "unknown interface $interface_id in LLDP info, ignoring"
+                $logger->debug(
+                    "LLDP support: unknown interface $interface_id in LLDP info, ignoring"
                 ) if $logger;
                 next;
             }
@@ -1066,8 +1066,8 @@ sub _setConnectedDevices {
         foreach my $interface_id (keys %$cdp_info) {
             # safety check
             if (! exists $ports->{$interface_id}) {
-                $logger->warning(
-                    "unknown interface $interface_id in CDP info, ignoring"
+                $logger->debug(
+                    "CDP support: unknown interface $interface_id in CDP info, ignoring"
                 ) if $logger;
                 next;
             }
@@ -1084,8 +1084,8 @@ sub _setConnectedDevices {
                     }
                 } else {
                     # undecidable situation
-                    $logger->warning(
-                        "multiple neighbors found by LLDP and CDP for " .
+                    $logger->debug(
+                        "CDP support: multiple neighbors found by LLDP and CDP for " .
                         "interface $interface_id, ignoring"
                     );
                     delete $port->{CONNECTIONS};
@@ -1104,8 +1104,8 @@ sub _setConnectedDevices {
         foreach my $interface_id (keys %$edp_info) {
             # safety check
             if (! exists $ports->{$interface_id}) {
-                $logger->warning(
-                    "unknown interface $interface_id in EDP info, ignoring"
+                $logger->debug(
+                    "EDP support: unknown interface $interface_id in EDP info, ignoring"
                 ) if $logger;
                 next;
             }
@@ -1122,8 +1122,8 @@ sub _setConnectedDevices {
                     }
                 } else {
                     # undecidable situation
-                    $logger->warning(
-                        "multiple neighbors found by LLDP and EDP for " .
+                    $logger->debug(
+                        "EDP support: multiple neighbors found by LLDP and EDP for " .
                         "interface $interface_id, ignoring"
                     );
                     delete $port->{CONNECTIONS};
@@ -1290,8 +1290,8 @@ sub _getCDPInfo {
         # warning: multiple neighbors announcement for the same interface
         # usually means a non-CDP aware intermediate equipement
         if ($results->{$interface_id}) {
-            $logger->warning(
-                "multiple neighbors found by CDP for interface $interface_id," .
+            $logger->debug(
+                "CDP support: multiple neighbors found by CDP for interface $interface_id," .
                 " ignoring"
             );
             $blacklist->{$interface_id} = 1;
@@ -1345,8 +1345,8 @@ sub _getEDPInfo {
         # warning: multiple neighbors announcement for the same interface
         # usually means a non-EDP aware intermediate equipement
         if ($results->{$interface_id}) {
-            $logger->warning(
-                "multiple neighbors found by EDP for interface $interface_id," .
+            $logger->debug(
+                "EDP support: multiple neighbors found by EDP for interface $interface_id," .
                 " ignoring"
             );
             $blacklist->{$interface_id} = 1;
@@ -1376,7 +1376,7 @@ sub _setVlans {
     foreach my $port_id (keys %$vlans) {
         # safety check
         if (! exists $ports->{$port_id}) {
-            $logger->error(
+            $logger->debug(
                 "invalid interface ID $port_id while setting vlans, aborting"
             ) if $logger;
             last;
@@ -1461,7 +1461,7 @@ sub _setTrunkPorts {
     foreach my $port_id (keys %$trunk_ports) {
         # safety check
         if (! exists $ports->{$port_id}) {
-            $logger->error(
+            $logger->debug(
                 "invalid interface ID $port_id while setting trunk flag, " .
                 "aborting"
             ) if $logger;
@@ -1539,7 +1539,7 @@ sub _setAggregatePorts {
         foreach my $interface_id (keys %$lacp_info) {
             # safety check
             if (!$ports->{$interface_id}) {
-                $logger->warning(
+                $logger->debug(
                     "unknown interface $interface_id in LACP info, ignoring"
                 ) if $logger;
                 next;
@@ -1553,7 +1553,7 @@ sub _setAggregatePorts {
         foreach my $interface_id (keys %$pagp_info) {
             # safety check
             if (!$ports->{$interface_id}) {
-                $logger->error(
+                $logger->debug(
                     "unknown interface $interface_id in PAGP info, ignoring"
                 ) if $logger;
                 next;

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -1210,7 +1210,7 @@ sub _getLLDPInfo {
         # duplicating chassiId
         my $portId = $lldpRemPortId->{$suffix};
         if ($portId !~ /^0x/ or length($portId) != 14) {
-            $connection->{IFNUMBER} = $portId;
+            $connection->{IFNUMBER} = getCanonicalString($portId);
         }
 
         my $ifdescr = getCanonicalString($lldpRemPortDesc->{$suffix});
@@ -1265,7 +1265,7 @@ sub _getCDPInfo {
         if ($devicePort =~ /^\d+$/) {
             $connection->{IFNUMBER} = $devicePort;
         } else {
-            $connection->{IFDESCR} = $devicePort;
+            $connection->{IFDESCR} = getCanonicalString($devicePort);
         }
 
         # cdpCacheDeviceId is either remote host name, either remote mac address
@@ -1337,8 +1337,8 @@ sub _getEDPInfo {
 
         my $connection = {
             IP       => $ip,
-            IFDESCR  => $edpNeighborPort->{$short_suffix},
-            SYSNAME  => $edpNeighborName->{$short_suffix},
+            IFDESCR  => getCanonicalString($edpNeighborPort->{$short_suffix}),
+            SYSNAME  => getCanonicalString($edpNeighborName->{$short_suffix}),
             SYSMAC   => sprintf "%02x:%02x:%02x:%02x:%02x:%02x", @mac_elements
         };
 

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -683,7 +683,9 @@ sub _setPrinterProperties {
         }
 
         if (!$type) {
-            $logger->debug("unknown consumable type $type_id") if $logger;
+            $logger->debug("unknown consumable type $type_id: ".
+                ($descriptions->{$consumable_id} || "no description")
+            ) if $logger;
             next;
         }
 

--- a/lib/FusionInventory/Agent/Tools/SNMP.pm
+++ b/lib/FusionInventory/Agent/Tools/SNMP.pm
@@ -12,6 +12,7 @@ our @EXPORT = qw(
     getCanonicalMacAddress
     getCanonicalConstant
     isInteger
+    getRegexpOidMatch
 );
 
 sub getCanonicalSerialNumber {
@@ -108,6 +109,17 @@ sub getCanonicalConstant {
     return $1 if $value =~ /\((\d+)\)$/;
 }
 
+sub getRegexpOidMatch {
+    my ($match) = @_;
+
+    return $match unless $match && $match =~ /^[0-9.]+$/;
+
+    # Protect dots for regexp compilation
+    $match =~ s/\./\\./g;
+
+    return qr/^$match/;
+}
+
 1;
 __END__
 
@@ -140,3 +152,7 @@ return a clean integer value.
 =head2 isInteger($value)
 
 return true if value is an integer.
+
+=head2 getRegexpOidMatch($oid)
+
+return compiled regexp to match given oid.

--- a/lib/FusionInventory/Agent/Tools/SNMP.pm
+++ b/lib/FusionInventory/Agent/Tools/SNMP.pm
@@ -39,10 +39,10 @@ sub getCanonicalString {
     $value =~ s/^\\?["']//;
     $value =~ s/\\?["']$//;
 
-    return unless defined $value;
-
     # Be sure to work on utf-8 string
     $value = getUtf8String($value);
+
+    return unless defined $value;
 
     # reduce linefeeds which can be found in descriptions or comments
     $value =~ s/\p{Control}+\n/\n/g;


### PR DESCRIPTION
* Added support for HP Net Peripheral, involving better HP printers inventory
  - Get Serial number & firmware version
  - Fix total printed pages counter in many case
  - Added total color pages counter support
* Don't assume colors table was read: fixes black toner detection on many HP printers
* Updated LLDP support to avoid annoying errors
