### PR TITLE
Update nmap options for NetDiscovery task

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,6 +18,8 @@ netdiscovery/netinventory:
   upgrades done server-side.
 * Fix discovery of devices with only ping responding and without found hostname. In
   that case, we default the DNSHOSTNAME to the scanned ip.
+* Update nmap options to also send a ICMP echo request, so devices not supporting
+  ICMP timestamp requests can also be discovered
 
 2.4 Fri, 29 Dec 2017
 core:

--- a/lib/FusionInventory/Agent/Task/NetDiscovery.pm
+++ b/lib/FusionInventory/Agent/Task/NetDiscovery.pm
@@ -110,7 +110,7 @@ sub run {
            pattern => qr/Nmap version (\d+)\.(\d+)/
        );
        $nmap_parameters = compareVersion($major, $minor, 5, 29) ?
-           "-sP -PP --system-dns --max-retries 1 --max-rtt-timeout 1000ms" :
+           "-sP -PE -PP --system-dns --max-retries 1 --max-rtt-timeout 1000ms" :
            "-sP --system-dns --max-retries 1 --max-rtt-timeout 1000ms"     ;
     } else {
         $self->{logger}->info(


### PR DESCRIPTION
Add -PE option to nmap to also send ICMP echo requests, so devices not supporting
ICMP timestamp requests can also be discovered.