### PR TITLE
Feature/maintenance task update

### DIFF
--- a/lib/FusionInventory/Agent/Target/Scheduler.pm
+++ b/lib/FusionInventory/Agent/Target/Scheduler.pm
@@ -44,12 +44,19 @@ sub getType {
 sub plannedTasks {
     my $self = shift @_;
 
-    # Keep only Maintenance as local task
+    # Keep only Maintenance as local task, but keep others
     if (@_) {
         $self->{tasks} = [ grep { $_ =~ /^Maintenance$/i } @_ ];
+        $self->{others} = [ grep { $_ !~ /^Maintenance$/i } @_ ];
     }
 
     return @{$self->{tasks} || []};
+}
+
+sub otherTasks {
+    my $self = shift @_;
+
+    return @{$self->{others} || []};
 }
 
 sub _loadState {

--- a/lib/FusionInventory/Agent/Task/Deploy/Maintenance.pm
+++ b/lib/FusionInventory/Agent/Task/Deploy/Maintenance.pm
@@ -51,6 +51,23 @@ This module provides the Maintenance run function to cleanup Deploy environment.
 
 =head1 FUNCTIONS
 
-=head2 doMaintenance ( $class,  %params )
+=head2 new(%params)
+
+The constructor. The following parameters are allowed, as keys of the %params
+hash:
+
+=over
+
+=item I<logger>
+
+the logger object to use (default: a new stderr logger)
+
+=item I<config>
+
+=item I<target>
+
+=back
+
+=head2 doMaintenance()
 
 Cleanup the deploy datastore associated with the target.

--- a/lib/FusionInventory/Agent/Task/Deploy/Maintenance.pm
+++ b/lib/FusionInventory/Agent/Task/Deploy/Maintenance.pm
@@ -1,0 +1,56 @@
+package FusionInventory::Agent::Task::Deploy::Maintenance;
+
+use strict;
+use warnings;
+
+use FusionInventory::Agent::Logger;
+use FusionInventory::Agent::Storage;
+use FusionInventory::Agent::Task::Deploy::Datastore;
+
+sub new {
+    my ($class, %params) = @_;
+
+    die 'no target parameter\n' unless $params{target};
+    die 'no config parameter\n' unless $params{config};
+
+    my $self = {
+        logger       => $params{logger} ||
+                        FusionInventory::Agent::Logger->new(),
+        config       => $params{config},
+        target       => $params{target},
+    };
+    bless $self, $class;
+
+    return $self;
+}
+
+sub doMaintenance {
+    my ($self) = @_;
+
+    my $folder = $self->{target}->getStorage()->getDirectory();
+    my $datastore = FusionInventory::Agent::Task::Deploy::Datastore->new(
+        config => $self->{config},
+        path   => $folder.'/deploy',
+        logger => $self->{logger}
+    );
+
+    $datastore->cleanUp( force => $datastore->diskIsFull() );
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+FusionInventory::Agent::Task::Deploy::Maintenance - Maintenance for Deploy task
+
+=head1 DESCRIPTION
+
+This module provides the Maintenance run function to cleanup Deploy environment.
+
+=head1 FUNCTIONS
+
+=head2 doMaintenance ( $class,  %params )
+
+Cleanup the deploy datastore associated with the target.

--- a/lib/FusionInventory/Agent/Task/Maintenance.pm
+++ b/lib/FusionInventory/Agent/Task/Maintenance.pm
@@ -5,8 +5,10 @@ use warnings;
 
 use parent 'FusionInventory::Agent::Task';
 
-use FusionInventory::Agent::Storage;
-use FusionInventory::Agent::Task::Deploy::Datastore;
+use English qw(-no_match_vars);
+use UNIVERSAL::require;
+use File::Basename;
+
 use FusionInventory::Agent::Task::Maintenance::Version;
 
 our $VERSION = FusionInventory::Agent::Task::Maintenance::Version::VERSION;
@@ -14,25 +16,58 @@ our $VERSION = FusionInventory::Agent::Task::Maintenance::Version::VERSION;
 sub isEnabled {
     my ($self) = @_;
 
-    if (!$self->{target}->isa('FusionInventory::Agent::Target::Scheduler')) {
+    if (!$self->{target}->isType('scheduler')) {
         $self->{logger}->debug("Maintenance task only compatible with Scheduler target");
         return;
     }
 
-    return 1;
+    my $found = 0;
+    # Lookup for each target task if a Maintenance module exists
+    foreach my $task ($self->{target}->otherTasks()) {
+        my $taskdir = dirname(__FILE__) .'/'. ucfirst($task);
+        next unless -d $taskdir;
+
+        my $maintenance = $taskdir.'/Maintenance.pm';
+        next unless -e $maintenance;
+
+        $found ++;
+        last;
+    }
+
+    return $found;
 }
 
 sub run {
-    my ($self, %params) = @_;
+    my ($self) = @_;
 
     my $logger = $self->{logger};
-    my $folder = $self->{target}->getStorage()->getDirectory();
-    my $datastore = FusionInventory::Agent::Task::Deploy::Datastore->new(
-        config => $self->{config},
-        path   => $folder.'/deploy',
-        logger => $logger
-    );
-    $datastore->cleanUp( force => $datastore->diskIsFull() );
+    my @taskclass = split('::', __PACKAGE__);
+    pop @taskclass;
+
+    # Lookup for each target task if a Maintenance module exists and run
+    # the its doMaintenance() API
+    foreach my $task ($self->{target}->otherTasks()) {
+        my $taskdir = dirname(__FILE__) .'/'. ucfirst($task);
+        next unless -d $taskdir;
+
+        my $file = $taskdir.'/Maintenance.pm';
+        next unless -e $file;
+
+        my $module = join('::', @taskclass, ucfirst($task), 'Maintenance');
+        $module->require();
+        if ($EVAL_ERROR) {
+            $logger->debug("failed to load $task maintenance module: $EVAL_ERROR");
+           next;
+        }
+
+        $logger->debug2("Doing $task Maintenance");
+        my $maintenance = $module->new(
+            target  => $self->{target},
+            config  => $self->{config},
+            logger  => $logger,
+        );
+        $maintenance->doMaintenance();
+    }
 }
 
 1;
@@ -52,8 +87,11 @@ and safe.
 
 =head2 isEnabled ( $self )
 
-Returns true if the task is enabled.
+Lookup for a Maintenance module for each target enabled tasks.
 
-=head2 run ( $self, %params )
+Returns true if the task should be finally enabled.
 
-Run the task.
+=head2 run ( $self )
+
+Run the Maintenance task by calling each doMaintenance() API from each
+task Maintenance found modules.

--- a/lib/FusionInventory/Agent/Task/Maintenance.pm
+++ b/lib/FusionInventory/Agent/Task/Maintenance.pm
@@ -85,13 +85,13 @@ and safe.
 
 =head1 FUNCTIONS
 
-=head2 isEnabled ( $self )
+=head2 isEnabled()
 
 Lookup for a Maintenance module for each target enabled tasks.
 
 Returns true if the task should be finally enabled.
 
-=head2 run ( $self )
+=head2 run()
 
 Run the Maintenance task by calling each doMaintenance() API from each
 task Maintenance found modules.

--- a/lib/FusionInventory/Agent/Task/Maintenance/Version.pm
+++ b/lib/FusionInventory/Agent/Task/Maintenance/Version.pm
@@ -3,6 +3,6 @@ package FusionInventory::Agent::Task::Maintenance::Version;
 use strict;
 use warnings;
 
-use constant VERSION => "1.0";
+use constant VERSION => "1.1";
 
 1;

--- a/t/tasks/maintenance.t
+++ b/t/tasks/maintenance.t
@@ -1,0 +1,111 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use lib 't/lib';
+
+use File::Basename;
+use File::Temp qw(tempdir);
+use File::Path qw(mkpath);
+
+use Test::Exception;
+use Test::More;
+use Test::MockModule;
+
+use FusionInventory::Agent::Logger;
+use FusionInventory::Agent::Task::Maintenance;
+use FusionInventory::Agent::Target::Local;
+use FusionInventory::Agent::Target::Server;
+use FusionInventory::Agent::Target::Scheduler;
+
+plan tests => 22;
+
+# Setup a target with a Fatal logger and no debug
+my $logger = FusionInventory::Agent::Logger->new(
+    logger => [ 'Test' ]
+);
+
+my $local = FusionInventory::Agent::Target::Local->new(
+    path       => tempdir(CLEANUP => 1),
+    logger     => $logger,
+    basevardir => tempdir(CLEANUP => 1)
+);
+
+my $server = FusionInventory::Agent::Target::Server->new(
+    url        => 'http://localhost/glpi-any',
+    logger     => $logger,
+    basevardir => tempdir(CLEANUP => 1)
+);
+
+my $scheduler = FusionInventory::Agent::Target::Scheduler->new(
+    storage    => $server->getStorage(),
+    logger     => $logger,
+    basevardir => tempdir(CLEANUP => 1)
+);
+
+my $task;
+
+lives_ok {
+    $task = FusionInventory::Agent::Task::Maintenance->new(
+        target => $local,
+        logger => FusionInventory::Agent::Logger->new( 'debug' => 1 ),
+        config => {}
+    );
+} "Maintenance object instanciation for local target" ;
+ok( ! $task->isEnabled(), "Maintenance is disabled for local target");
+
+lives_ok {
+    $task = FusionInventory::Agent::Task::Maintenance->new(
+        target => $server,
+        logger => FusionInventory::Agent::Logger->new( 'debug' => 1 ),
+        config => {}
+    );
+} "Maintenance object instanciation for server target" ;
+ok( ! $task->isEnabled(), "Maintenance is disabled for server target");
+
+lives_ok {
+    $task = FusionInventory::Agent::Task::Maintenance->new(
+        target => $scheduler,
+        logger => FusionInventory::Agent::Logger->new( 'debug' => 1 ),
+        config => {}
+    );
+} "Maintenance object instanciation for scheduler target" ;
+is(scalar($scheduler->plannedTasks()), 0, "No planned task for scheduler");
+is(scalar($scheduler->otherTasks()), 0, "No other tasks");
+ok( ! $task->isEnabled(), "Maintenance is disabled for scheduler without task");
+
+$scheduler->plannedTasks('Inventory', 'Something');
+is(scalar($scheduler->plannedTasks()), 0, "No planned task for scheduler");
+is(scalar($scheduler->otherTasks()), 2, "2 other tasks");
+ok( ! $task->isEnabled(), "Maintenance is disabled for scheduler but without Maintenance task");
+
+# Only Maintenance is kept as task, but we need at least Deploy in others
+$scheduler->plannedTasks('Inventory', 'TaskXYZ', 'Maintenance','Deploy');
+is(scalar($scheduler->plannedTasks()), 1, "One planned tasks for scheduler");
+is(scalar($scheduler->otherTasks()), 3, "3 other tasks");
+ok( $task->isEnabled(), "Maintenance is enabled for scheduler");
+
+lives_ok {
+    $task->run();
+} "Doing maintenance";
+
+# Test Deploy maintenance module
+my $folder = $scheduler->getStorage()->getDirectory().'/deploy/fileparts/private';
+my @files = map { $folder.'/'.$_.'/test' } (0,time-60,time+3600);
+foreach my $file (@files) {
+    File::Path::mkpath(dirname($file));
+    open FILE, ">$file" or die "Can't create tmp file: $!\n";
+    print FILE "TEST\n";
+    close(FILE);
+}
+ok( -f $files[0], "File exists in folder 0");
+ok( -f $files[1], "File exists in past folder");
+ok( -f $files[2], "File exists in future folder");
+
+lives_ok {
+    $task->run();
+} "Doing Deploy maintenance";
+
+ok( ! -f $files[0], "File removed in folder 0");
+ok( ! -f $files[1], "File removed in past folder");
+ok( -f $files[2], "File exists in future folder");


### PR DESCRIPTION
This update permit to handle a dedicated Maintenance module by task.
Actually only Deploy Maintenance module is supported to nicely handle file retention.
It also fixes some log error while Deploy module was not installed with 2.4.1 agent and as FusionInventory::Agent::Task::Deploy::Datastore package was not found.