### PR TITLE
fix cpu core computation

### DIFF
--- a/Changes
+++ b/Changes
@@ -36,6 +36,7 @@ deploy:
 esx:
 * Support 2 ServiceTags case to cover chassis & lame board S/N inventory
 * Updated AssetTag support
+* fix wrong cpu core computation when only one package is available
 
 netdiscovery/netinventory:
 * Thanks to @QuickNerd357, Brocade devices will now show serial number and

--- a/lib/FusionInventory/Agent/SOAP/VMware/Host.pm
+++ b/lib/FusionInventory/Agent/SOAP/VMware/Host.pm
@@ -112,12 +112,14 @@ sub getCPUs {
     my $totalCore   = $hardware->{cpuInfo}{numCpuCores};
     my $totalThread = $hardware->{cpuInfo}{numCpuThreads};
     my $cpuEntries  = $hardware->{cpuPkg};
+    my $cpuPackages = $hardware->{cpuInfo}{numCpuPackages} ||
+        scalar(_asArray($cpuEntries));
 
     my @cpus;
     foreach (_asArray($cpuEntries)) {
         push @cpus,
           {
-            CORE         => $totalCore / _asArray($cpuEntries),
+            CORE         => eval { $totalCore / $cpuPackages },
             MANUFACTURER => $cpuManufacturor{ $_->{vendor} } || $_->{vendor},
             NAME         => $_->{description},
             SPEED        => int( $_->{hz} / ( 1000 * 1000 ) ),


### PR DESCRIPTION
fix wrong computation when only one package is available as
totalCore was divided by the reference value, not just 1.