### PR TITLE
Feature: better snmp mock performance

### DIFF
--- a/Changes
+++ b/Changes
@@ -37,6 +37,9 @@ maintenance:
 * bump Maintenance task version to 1.1
 * disable Maintenance task if no maintenance module could be used
 
+test suite:
+* make snmp walk tests faster
+
 2.4.1 Fri, 29 Jun 2018
 
 core:

--- a/lib/FusionInventory/Agent/SNMP/Mock.pm
+++ b/lib/FusionInventory/Agent/SNMP/Mock.pm
@@ -99,12 +99,6 @@ sub _setIndexedValues {
     my $numerical = substr($first_line, 0, 1) eq '.' ? 1 : 0 ;
     my $last_value;
 
-    # Prepare walk tree root with an empty node
-    # 1st value node will contain sub-nodes
-    # 2nd value will be the numder index
-    # 3rd value will be a hash of sub-index -> sub-node ref in 1st values
-    # 4th value will be a SNMP value array ref like [ TYPE, VALUE ] when
-    #     a value should be stored
     $self->{_walk} = {};
 
     while (my $line = <$handle>) {
@@ -179,6 +173,12 @@ sub _setValue {
     # Optimization: use 6 first oid digits as tree root key as they don't often change
     my ($root, $nextoidpart) = $oid =~ /^(\.\d+\.\d+\.\d+\.\d+\.\d+\.\d+)(.*)$/
         or return;
+    # Prepare walk tree roots with empty node while not exist
+    # 1st value node will contain sub-nodes
+    # 2nd value will be the numder index
+    # 3rd value will be a hash of sub-index -> sub-node ref in 1st values
+    # 4th value will be a SNMP value array ref like [ TYPE, VALUE ] when
+    #     a value should be stored
     $self->{_walk}->{$root} = [ [], undef, {}, undef ] unless exists($self->{_walk}->{$root});
     $oid = $nextoidpart;
 

--- a/lib/FusionInventory/Agent/SNMP/Mock.pm
+++ b/lib/FusionInventory/Agent/SNMP/Mock.pm
@@ -202,22 +202,15 @@ sub _setValue {
 sub _getValue {
     my ($self, $oid, $walk) = @_;
 
-    my @oid = split(/\./, $oid);
-    shift @oid;
-
     my $base = $self->{_walk};
-    my ($num, $ref);
-    while (@oid) {
-        $num = shift @oid;
+    foreach my $num (split(/\./, substr($oid,1))) {
         # No value if no subnode indexed
-        return unless $ref = $base->[2];
-        $ref = $base->[2]->{$num};
-        # No value if requested subnode is not indexed
-        return unless $ref;
-        $base = $ref;
+        # Also no value if requested subnode is not indexed
+        return unless $base->[2] && $base->[2]->{$num};
+        $base = $base->[2]->{$num};
     }
 
-    return $walk ? $ref : $ref->[3];
+    return $walk ? $base : $base->[3];
 }
 
 sub get {

--- a/lib/FusionInventory/Agent/SNMP/Mock.pm
+++ b/lib/FusionInventory/Agent/SNMP/Mock.pm
@@ -260,6 +260,9 @@ sub walk {
     my $base = $self->_getValue($oid, 1)
         or return;
 
+    # Don't walk unless subnodes exist
+    return unless $base->[0];
+
     return _deepwalk($base);
 }
 

--- a/lib/FusionInventory/Agent/SNMP/Mock.pm
+++ b/lib/FusionInventory/Agent/SNMP/Mock.pm
@@ -53,7 +53,10 @@ sub new {
         }
 
         if ($params{hash}) {
-            $self->{values} = $params{hash};
+            $self->{_walk} = [ [], undef, undef, {} ];
+            foreach my $oid (keys(%{$params{hash}})) {
+                $self->_setOid($oid, $params{hash}->{$oid});
+            }
             last SWITCH;
         }
     }
@@ -138,6 +141,7 @@ sub _setIndexedValues {
         }
 
         last if $line =~ /No more variables left in this MIB View/;
+        last if $line =~ /^End of MIB$/;
 
         # potential continuation
         if ($line !~ /^$/ && $line !~ /= ""$/ && $last_value) {

--- a/lib/FusionInventory/Agent/SNMP/Mock.pm
+++ b/lib/FusionInventory/Agent/SNMP/Mock.pm
@@ -176,31 +176,27 @@ sub _setIndexedValues {
 sub _setValue {
     my ($self, $oid, $value) = @_;
 
-    my @oid = split(/\./, $oid);
-    shift @oid;
-
     my $base = $self->{_walk};
-    my ($num, $ref);
-    while (@oid) {
-        $num = shift @oid;
-        # Get node ref if indexed
-        $ref = $base->[2]->{$num} if $base->[2];
-        # Otherwise initialize a new node
-        unless ($ref) {
-            $ref = [undef, $num, {}];
+    foreach my $num (split(/\./, substr($oid,1))) {
+        # Get subnode ref if indexed
+        if ($base->[2] && $base->[2]->{$num}) {
+            $base = $base->[2]->{$num};
+        # Otherwise initialize a new subnode
+        } else {
+            my $ref = [undef, $num, {}];
             # Initialize an array ref as subnode if necessary
             $base->[0] = [] unless $base->[0];
             # Push new sub-node in list
             push @{$base->[0]}, $ref;
             # Index sub-node
             $base->[2]->{$num} = $ref;
+            # New subnode becomes the base node
+            $base = $ref;
         }
-        # subnode becomes the base node
-        $base = $ref;
     }
     # Keep value in leaf
-    $ref->[2] = undef;
-    $ref->[3] = $value;
+    $base->[2] = undef;
+    $base->[3] = $value;
 }
 
 sub _getValue {

--- a/lib/FusionInventory/Agent/SNMP/Mock.pm
+++ b/lib/FusionInventory/Agent/SNMP/Mock.pm
@@ -67,21 +67,21 @@ sub new {
 sub switch_vlan_context {
     my ($self, $vlan_id) = @_;
 
-    $self->{oldvalues} = $self->{values} unless $self->{oldvalues};
+    $self->{_oldwalk} = $self->{_walk} unless $self->{_oldwalk};
 
     my $file = $self->{file} . '@' . $vlan_id;
     if (-r $file && -f $file) {
         $self->_setIndexedValues($file);
     } else {
-        delete $self->{values};
+        delete $self->{_walk};
     }
 }
 
 sub reset_original_context {
     my ($self) = @_;
 
-    $self->{values} = $self->{oldvalues};
-    delete $self->{oldvalues};
+    $self->{_walk} = $self->{_oldwalk} if $self->{_oldwalk};
+    delete $self->{_oldwalk};
 }
 
 sub _setIndexedValues {

--- a/lib/FusionInventory/Agent/SNMP/Mock.pm
+++ b/lib/FusionInventory/Agent/SNMP/Mock.pm
@@ -223,21 +223,22 @@ sub get {
 sub _deepwalk {
     my ($base) = @_;
 
-    my $array = [];
+    my $hash = {};
 
     foreach my $ref (@{$base->[0]}) {
         my $key = $ref->[1];
         if (defined($ref->[3])) {
-            push @{$array}, [ $key, _getSanitizedValue(@{$ref->[3]}) ];
-        } else {
+            $hash->{$key} = _getSanitizedValue(@{$ref->[3]});
+        }
+        if ($ref->[0]) {
             my $subkeys = _deepwalk($ref);
-            foreach my $subkey (@{$subkeys}) {
-                push @{$array}, [ $key.".".($subkey->[0]), $subkey->[1] ];
+            foreach my $subkey (keys(%{$subkeys})) {
+                $hash->{$key.".".$subkey} = $subkeys->{$subkey};
             }
         }
     }
 
-    return $array;
+    return $hash;
 }
 
 sub walk {
@@ -248,9 +249,7 @@ sub walk {
     my $base = $self->_getOid($oid, 1)
         or return;
 
-    my $walk = _deepwalk($base);
-
-    return { map { $_->[0] => $_->[1] } @{$walk} };
+    return _deepwalk($base);
 }
 
 sub _getSanitizedValue {


### PR DESCRIPTION
This update permits to divide by 3 the time passed to handle a bunch of big test snmp walks. On my dev station, the run time was more than 12 minutes before for our private snmpwalk repository, and it is now less than 4 minutes.

The update optimize the way OID are stored and accessed. The longer step is still far the file loading and OID indexing time.